### PR TITLE
Fix current timetable issue [SNUTT-305]

### DIFF
--- a/SNUTT/MenuViewController.swift
+++ b/SNUTT/MenuViewController.swift
@@ -69,6 +69,7 @@ class MenuViewController: UIViewController {
         registerCellXib()
         registerHeaderView()
         
+        fetchCurrentTimetable()
         fetchTablelist()
         
         STEventCenter.sharedInstance.addObserver(self, selector: #selector(self.reloadList), event: STEvent.CourseBookUpdated, object: nil)
@@ -328,5 +329,15 @@ extension MenuViewController: SettingViewControllerDelegate {
         } failure: {
             STAlertView.showAlert(title: "시간표 삭제 실패", message: "")
         }
+    }
+}
+
+extension MenuViewController {
+    private func fetchCurrentTimetable() {
+        STNetworking.getRecentTimetable({ timetable in
+            STTimetableManager.sharedInstance.currentTimetable = timetable
+        }, failure: {
+            STAlertView.showAlert(title: "시간표 로딩 실패", message: "시간표가 서버에 존재하지 않습니다.")
+        })
     }
 }

--- a/SNUTT/STTimetableTabViewController.swift
+++ b/SNUTT/STTimetableTabViewController.swift
@@ -48,6 +48,8 @@ class STTimetableTabViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        fetchCurrentTimetable()
+        
         // Add tap recognizer to title in NavigationBar
         let titleView = UILabel()
         titleView.text = currentTimetable?.title ?? ""
@@ -486,6 +488,16 @@ extension STTimetableTabViewController: MenuViewControllerDelegate {
                 
             }
         }
+    }
+}
+
+extension STTimetableTabViewController {
+    private func fetchCurrentTimetable() {
+        STNetworking.getRecentTimetable({ timetable in
+            STTimetableManager.sharedInstance.currentTimetable = timetable
+        }, failure: {
+            STAlertView.showAlert(title: "시간표 로딩 실패", message: "시간표가 서버에 존재하지 않습니다.")
+        })
     }
 }
 


### PR DESCRIPTION
"시간표가 안 떠요" 이슈들에 대한 해결

### 원인
- fetch current timetable이 로그인 할 때만 호출됨
- api가 업데이트 되거나, userDafault가 업데이트 됐음에도, 이미 로그인한 상태이기 때문에 current timetable을 호출하지 않아 current timtable을 기반으로 작성된 로직들이 작동하지 않았던 것으로 보임

### 해결
- 주요 view load에 fetch current timetable api 호출

api 호출 코드, current timetable 코드가 너무 복잡하게 얽혀 있음. 리팩토링이 시급하다.