### PR TITLE
[SNUTT-371] 사이드메뉴에서 시간표 이름 변경하면 시간표가 사라지는 문제

### DIFF
--- a/SNUTT/MenuViewController.swift
+++ b/SNUTT/MenuViewController.swift
@@ -294,12 +294,13 @@ extension MenuViewController: SettingViewControllerDelegate {
         }
         
         STNetworking.updateTimetable(id, title: title, done: { timetableList in
-            if self.currentTimetable?.id == timetable.id {
+            if let currentTimetable = self.currentTimetable, currentTimetable.id == timetable.id {
                 let updatedTimetable = timetableList.filter({ tt in
                     return tt.id == timetable.id
                 })
                 
-                STTimetableManager.sharedInstance.currentTimetable = updatedTimetable[0]
+                currentTimetable.title = updatedTimetable[0].title
+                STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: nil)
             }
             
             self.timetableList = timetableList


### PR DESCRIPTION
# 수정 사항

- 시간표 이름을 변경해도 시간표가 사라지지 않도록 수정했습니다.
- 시간표 변경 시 돌아오는 API 응답에는 강의 데이터가 포함되지 않는데, 이를 강제로 디코딩하여 `currentTimetable`에 할당해서 발생한 문제였습니다.