### PR TITLE
위젯 깨지는 문제 수정

### DIFF
--- a/SNUTT Today/Base.lproj/MainInterface.storyboard
+++ b/SNUTT Today/Base.lproj/MainInterface.storyboard
@@ -24,6 +24,9 @@
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RaS-jH-fp2" customClass="STTimetableCollectionView" customModule="SNUTT_Today" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="400"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="400" id="Rbb-PT-hgO"/>
+                                </constraints>
                             </containerView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yob-Pd-1js">
                                 <rect key="frame" x="31" y="0.0" width="258" height="400"/>
@@ -38,7 +41,6 @@
                             <constraint firstAttribute="trailingMargin" secondItem="yob-Pd-1js" secondAttribute="trailing" constant="15" id="TCl-MV-tQW"/>
                             <constraint firstItem="RaS-jH-fp2" firstAttribute="top" secondItem="S3S-Oj-5AN" secondAttribute="top" id="Xcm-69-5wX"/>
                             <constraint firstAttribute="trailing" secondItem="RaS-jH-fp2" secondAttribute="trailing" id="egp-vj-VCh"/>
-                            <constraint firstAttribute="bottom" secondItem="RaS-jH-fp2" secondAttribute="bottom" id="h8g-3K-B43"/>
                             <constraint firstItem="yob-Pd-1js" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leadingMargin" constant="15" id="nAY-AI-5HZ"/>
                             <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="yob-Pd-1js" secondAttribute="bottom" id="tsm-tp-ATv"/>
                         </constraints>
@@ -57,6 +59,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="133" y="67"/>
         </scene>
     </scenes>
 </document>

--- a/SNUTT Today/TodayViewController.swift
+++ b/SNUTT Today/TodayViewController.swift
@@ -95,14 +95,12 @@ extension TodayViewController:NCWidgetProviding{
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize){
         if (activeDisplayMode == .compact) {
             self.preferredContentSize = maxSize
-            timetableView.frame.size = maxSize
             reloadData()
             timetableView.isHidden = true
             descriptionLabel.isHidden = false
         }
         else {
             self.preferredContentSize = CGSize(width: 0, height: maxHeight)
-            timetableView.frame.size = CGSize(width: 0, height: maxHeight)
             reloadData()
             timetableView.isHidden = false
             descriptionLabel.isHidden = true

--- a/SNUTT Today/TodayViewController.swift
+++ b/SNUTT Today/TodayViewController.swift
@@ -11,7 +11,7 @@ import NotificationCenter
 import SwiftyJSON
 import SwiftyUserDefaults
 
-class TodayViewController: UIViewController, NCWidgetProviding {
+class TodayViewController: UIViewController {
     //TODO: iOS 9 Testing
     
     @IBOutlet weak var timetableView: STTimetableCollectionView!
@@ -83,6 +83,15 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         }
     }
 
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+}
+
+extension TodayViewController:NCWidgetProviding{
+    
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize){
         if (activeDisplayMode == NCWidgetDisplayMode.compact) {
             self.preferredContentSize = maxSize
@@ -108,10 +117,5 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         });
 
         completionHandler(NCUpdateResult.newData)
-    }
-    
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
     }
 }

--- a/SNUTT Today/TodayViewController.swift
+++ b/SNUTT Today/TodayViewController.swift
@@ -93,7 +93,7 @@ class TodayViewController: UIViewController {
 extension TodayViewController:NCWidgetProviding{
     
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize){
-        if (activeDisplayMode == NCWidgetDisplayMode.compact) {
+        if (activeDisplayMode == .compact) {
             self.preferredContentSize = maxSize
             timetableView.frame.size = maxSize
             reloadData()


### PR DESCRIPTION
# 수정 사항
- `MainInterface.storyboard`에서 시간표 CollectionView의 bottom constraint를 제거하고 height constraint(constant: 400)를 추가했습니다.
   - 더보기 버튼을 눌렀을 때, collectionView는 즉각적으로 나타나지만 위젯의 높이는 애니메이션 효과 이후 늘어나게 됩니다.
   - collectionView의 top/bottom constraint가 *높이가 늘어나기 전* 위젯의 top/bottom으로 맞춰지면서 위젯 찌그러짐 문제가 발생하는 것으로 생각됩니다.
   - 따라서 위젯의 높이에 관계없이 collectionView의 height를 400으로 고정하기 위해 관련 auto layout을 수정했습니다. (높이는 원래부터 400 고정이었기 때문에 별 문제는 없다고 생각합니다.)
- `TodayViewController.swift`에서 frame를 통해 height를 조절하는 코드가 있었는데, 높이는 auto layout이 관리하고 있으므로 의미 없는 코드라고 판단하여 삭제했습니다.