### PR TITLE
시간표 테마 변경 관련 문제 수정 [SNUTT-394]

### DIFF
--- a/SNUTT/STTimetableTabViewController.swift
+++ b/SNUTT/STTimetableTabViewController.swift
@@ -366,6 +366,7 @@ extension STTimetableTabViewController {
             temporaryTheme = nil
             timetableView.reloadData()
         }
+        originalTheme = currentTimetable?.theme
         backgroundView.frame.size.width = 0
         backgroundView.isHidden = true
     }
@@ -421,7 +422,6 @@ extension STTimetableTabViewController {
             showBackgroundCoverView()
             UIView.animate(withDuration: 0.6, delay: 0, usingSpringWithDamping: 0.92, initialSpringVelocity: 0, options: .curveEaseInOut) {
                 self.themeSettingController?.view.frame.origin.y = self.tabBarController!.view.frame.height - (self.themeSettingController?.view.frame.height ?? 0)
-
             } completion: { _ in
                 self.themeSettingViewState = .opened
             }
@@ -490,7 +490,6 @@ extension STTimetableTabViewController {
     private func fetchCurrentTimetable() {
         STNetworking.getRecentTimetable({ [weak self] timetable in
             STTimetableManager.sharedInstance.currentTimetable = timetable
-            self?.originalTheme = timetable?.theme
         }, failure: {
             STAlertView.showAlert(title: "시간표 로딩 실패", message: "시간표가 서버에 존재하지 않습니다.")
         })

--- a/SNUTT/STTimetableTabViewController.swift
+++ b/SNUTT/STTimetableTabViewController.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2016년 WaffleStudio. All rights reserved.
 //
 
-import UIKit
 import LinkPresentation
+import UIKit
 
 class STTimetableTabViewController: UIViewController {
-    
     @IBOutlet weak var timetableView: STTimetableCollectionView!
     var menuController: MenuViewController!
     var themeSettingController: ThemeSettingViewController!
@@ -18,38 +17,39 @@ class STTimetableTabViewController: UIViewController {
     var currentTimetable: STTimetable? {
         return STTimetableManager.sharedInstance.currentTimetable
     }
+
     enum MenuControllerState {
         case opened
         case closed
     }
-    
+
     enum ThemeSettingViewState {
         case opened
         case closed
     }
-    
+
     var originalTheme: STTheme?
     var temporaryTheme: STTheme?
-    
-    var menuControllerState : MenuControllerState = .closed
-    var themeSettingViewState : ThemeSettingViewState = .closed
-    var isInAnimation : Bool = false
-    
+
+    var menuControllerState: MenuControllerState = .closed
+    var themeSettingViewState: ThemeSettingViewState = .closed
+    var isInAnimation: Bool = false
+
     @IBOutlet weak var containerView: UIView!
-    
+
     @IBOutlet weak var notiBarItem: UIBarButtonItem!
-    
+
     @IBOutlet var rightBarButtonsForTimetable: [UIBarButtonItem]!
-    
-    @IBAction func leftBarButtonItem(_ sender: UIBarButtonItem) {
+
+    @IBAction func leftBarButtonItem(_: UIBarButtonItem) {
         toggleMenuView()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         fetchCurrentTimetable()
-        
+
         // Add tap recognizer to title in NavigationBar
         let titleView = UILabel()
         titleView.text = currentTimetable?.title ?? ""
@@ -62,48 +62,46 @@ class STTimetableTabViewController: UIViewController {
 
         let leftTitleItem = UIBarButtonItem(customView: titleView)
         let leftCreditItem = UIBarButtonItem(customView: creditLabel)
-        self.navigationItem.leftBarButtonItems?.append(leftTitleItem)
-        self.navigationItem.leftBarButtonItems?.append(leftCreditItem)
-        
+        navigationItem.leftBarButtonItems?.append(leftTitleItem)
+        navigationItem.leftBarButtonItems?.append(leftCreditItem)
+
         addRightBarButtons()
-        
+
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(STTimetableTabViewController.titleWasTapped))
         titleView.isUserInteractionEnabled = true
         titleView.addGestureRecognizer(recognizer)
-        
-        self.navigationItem.leftBarButtonItem!.target = self
-        
+
+        navigationItem.leftBarButtonItem!.target = self
+
         timetableView.timetable = currentTimetable
         settingChanged()
-        
-        timetableView.cellLongClicked = self.cellLongClicked
-        timetableView.cellTapped = self.cellTapped
-        
-        let _ = STColorManager.sharedInstance
-        
+
+        timetableView.cellLongClicked = cellLongClicked
+        timetableView.cellTapped = cellTapped
+
+        _ = STColorManager.sharedInstance
+
         STEventCenter.sharedInstance.addObserver(self, selector: #selector(STTimetableTabViewController.reloadData), event: STEvent.CurrentTimetableChanged, object: nil)
         STEventCenter.sharedInstance.addObserver(self, selector: #selector(STTimetableTabViewController.reloadData), event: STEvent.CurrentTimetableSwitched, object: nil)
         STEventCenter.sharedInstance.addObserver(self, selector: #selector(STTimetableTabViewController.settingChanged), event: STEvent.SettingChanged, object: nil)
-        
+
         reloadData()
-        
+
         menuController = UIStoryboard(name: "Main", bundle: Bundle.main).instantiateViewController(withIdentifier: "MenuViewController") as! MenuViewController
         menuController.delegate = self
-        
+
         addMenuView()
         addThemeSettingView()
     }
-    
+
     private func addRightBarButtons() {
         let imageList: [UIImage?] = [UIImage(named: "list"), UIImage(named: "share"), UIImage(named: "tabAlarmOff")]
-        
-        
+
         for (index, item) in rightBarButtonsForTimetable.enumerated() {
             let button = UIButton()
             button.setImage(imageList[index], for: .normal)
             button.frame.size = CGSize(width: 30, height: 30)
-            
-            
+
             switch index {
             case 0:
                 button.addTarget(self, action: #selector(presentTimetableListView), for: .touchUpInside)
@@ -117,58 +115,58 @@ class STTimetableTabViewController: UIViewController {
             item.customView = button
         }
     }
-    
+
     @objc private func presentTimetableListView() {
         if let vc = UIStoryboard(name: "Main", bundle: Bundle.main).instantiateViewController(withIdentifier: "MyLectureListController") as? STMyLectureListController {
-            self.navigationController?.pushViewController(vc, animated: true)
+            navigationController?.pushViewController(vc, animated: true)
         }
     }
-    
+
     @objc private func presentNotiView() {
         if let vc = UIStoryboard(name: "Main", bundle: Bundle.main).instantiateViewController(withIdentifier: "NotiListController") as? STNotificationTableViewController {
-            self.navigationController?.pushViewController(vc, animated: true)
+            navigationController?.pushViewController(vc, animated: true)
         }
     }
-    
-    override func viewDidAppear(_ animated: Bool) {
+
+    override func viewDidAppear(_: Bool) {
         setNotiBadge(STDefaults[.shouldShowBadge])
     }
-    
+
     deinit {
         STEventCenter.sharedInstance.removeObserver(self)
     }
-    
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-    
+
     @objc func reloadData() {
-        guard let count = self.navigationItem.leftBarButtonItems?.count else {
+        guard let count = navigationItem.leftBarButtonItems?.count else {
             return
         }
-        if let titleView = self.navigationItem.leftBarButtonItems?[count -  2].customView as? UILabel, let creditLabel = self.navigationItem.leftBarButtonItems?[count - 1].customView as? UILabel {
+        if let titleView = navigationItem.leftBarButtonItems?[count - 2].customView as? UILabel, let creditLabel = navigationItem.leftBarButtonItems?[count - 1].customView as? UILabel {
             if let credit = currentTimetable?.totalCreditByCal, let title = currentTimetable?.title {
                 titleView.text = "\(title)"
                 creditLabel.text = credit != 0 ? "(\(String(credit)) 학점)" : ""
             }
-            
-            titleView.sizeToFit();
+
+            titleView.sizeToFit()
         }
-        
+
         timetableView.timetable = currentTimetable
         timetableView.reloadTimetable()
     }
-    
+
     @objc func settingChanged() {
         if STDefaults[.autoFit] {
             timetableView.shouldAutofit = true
         } else {
             timetableView.shouldAutofit = false
             let dayRange = STDefaults[.dayRange]
-            var columnHidden : [Bool] = []
-            for i in 0...6 {
-                if dayRange[0] <= i && i <= dayRange[1] {
+            var columnHidden: [Bool] = []
+            for i in 0 ... 6 {
+                if dayRange[0] <= i, i <= dayRange[1] {
                     columnHidden.append(false)
                 } else {
                     columnHidden.append(true)
@@ -180,7 +178,7 @@ class STTimetableTabViewController: UIViewController {
         }
         timetableView.reloadTimetable()
     }
-    
+
     @objc func titleWasTapped() {
         guard let currentTimetable = currentTimetable else {
             return
@@ -188,7 +186,7 @@ class STTimetableTabViewController: UIViewController {
         guard let timetableId = currentTimetable.id else {
             return
         }
-        
+
         STAlertView.showAlert(title: "시간표 이름 변경", message: "새로운 시간표 이름을 입력해주세요", configAlert: { alert in
             alert.addTextField(configurationHandler: { textfield in
                 textfield.placeholder = "새로운 시간표 이름"
@@ -196,7 +194,7 @@ class STTimetableTabViewController: UIViewController {
             alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
             alert.addAction(UIAlertAction(title: "이름 변경", style: .default, handler: { _ in
                 if let timetableName = alert.textFields?.first?.text {
-                    STNetworking.updateTimetable(timetableId, title: timetableName, done: {_ in 
+                    STNetworking.updateTimetable(timetableId, title: timetableName, done: { _ in
                         currentTimetable.title = timetableName
                         STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: nil)
                     }, failure: nil)
@@ -204,17 +202,16 @@ class STTimetableTabViewController: UIViewController {
             }))
         })
     }
-    
+
     func cellTapped(_ cell: STCourseCellCollectionViewCell) {
         let detailController = UIStoryboard(name: "Main", bundle: Bundle.main).instantiateViewController(withIdentifier: "LectureDetailTableViewController") as! STLectureDetailTableViewController
         detailController.lecture = cell.lecture
         detailController.theme = cell.theme
-        self.navigationController?.pushViewController(detailController, animated: true)
-        
+        navigationController?.pushViewController(detailController, animated: true)
     }
-    
-    func cellLongClicked (_ cell : STCourseCellCollectionViewCell) {
-        let oldColorIndex = cell.lecture.colorIndex;
+
+    func cellLongClicked(_ cell: STCourseCellCollectionViewCell) {
+        let oldColorIndex = cell.lecture.colorIndex
         guard let collectionView = timetableView else {
             return
         }
@@ -222,7 +219,7 @@ class STTimetableTabViewController: UIViewController {
             return
         }
         let num = collectionView.numberOfItems(inSection: indexPath.section)
-        let cellList : [STCourseCellCollectionViewCell?] = (0..<num).map { i in
+        let cellList: [STCourseCellCollectionViewCell?] = (0 ..< num).map { i in
             let tmpIndexPath = IndexPath(row: i, section: indexPath.section)
             return collectionView.cellForItem(at: tmpIndexPath) as? STCourseCellCollectionViewCell
         }
@@ -232,18 +229,19 @@ class STTimetableTabViewController: UIViewController {
             newLecture?.colorIndex = selectedColorIndex
             newLecture?.color = nil
             STTimetableManager.sharedInstance.updateLecture(
-                oldLecture, newLecture: newLecture!, done: {  return }, failure: {
+                oldLecture, newLecture: newLecture!, done: {}, failure: {
                     cellList.forEach { cell in
                         cell?.setColorByLecture(lecture: oldLecture)
                     }
-                })
+                }
+            )
         }, cancelBlock: {
             cellList.forEach { cell in
                 cell?.setColorByLecture(lecture: oldLecture)
             }
         }, selectedBlock: { colorIndex in
-            cellList.forEach { cell in
-                let color = STColorManager.sharedInstance.colorList.colorList[colorIndex-1]
+            cellList.forEach { _ in
+                let color = STColorManager.sharedInstance.colorList.colorList[colorIndex - 1]
                 //                    cell?.setColor(color: color)
             }
         }, origin: self)
@@ -252,28 +250,28 @@ class STTimetableTabViewController: UIViewController {
 
 extension STTimetableTabViewController: UIActivityItemSource {
     @objc func showCaptureAlert() {
-        let image = captureTimetableView(of: self.view)
-        
+        let image = captureTimetableView(of: view)
+
         let activityVC = UIActivityViewController(activityItems: [self, image], applicationActivities: nil)
-        activityVC.popoverPresentationController?.sourceView = self.view
-        
-        self.present(activityVC, animated: true, completion: nil)
+        activityVC.popoverPresentationController?.sourceView = view
+
+        present(activityVC, animated: true, completion: nil)
     }
-    
-    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+
+    func activityViewControllerPlaceholderItem(_: UIActivityViewController) -> Any {
         return ""
     }
 
-    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+    func activityViewController(_: UIActivityViewController, itemForActivityType _: UIActivity.ActivityType?) -> Any? {
         return nil
     }
 
-    func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+    func activityViewControllerLinkMetadata(_: UIActivityViewController) -> LPLinkMetadata? {
         let metadata = LPLinkMetadata()
         metadata.title = "SNUTT"
         return metadata
     }
-    
+
     func captureTimetableView(of view: UIView) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(
             CGSize(
@@ -283,11 +281,11 @@ extension STTimetableTabViewController: UIActivityItemSource {
             false,
             2
         )
-        
+
         view.layer.render(in: UIGraphicsGetCurrentContext()!)
         let screenshot = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
-        
+
         return screenshot
     }
 }
@@ -302,49 +300,50 @@ extension STTimetableTabViewController {
 }
 
 // MARK: Menu view stuff
+
 extension STTimetableTabViewController {
     private func addMenuView() {
         guard let menuVC = menuController else {
             return
         }
-        
-        menuController.view.frame.origin.x = -(self.containerView.frame.width)
-        
+
+        menuController.view.frame.origin.x = -(containerView.frame.width)
+
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapBackgroundView(_:)))
-        
+
         let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(didPanGestureActionInMenuView(_:)))
-        
+
         menuVC.view.addGestureRecognizer(panGestureRecognizer)
         backgroundView.addGestureRecognizer(tapGestureRecognizer)
     }
-    
-    @objc private func didTapBackgroundView(_ sender: UITapGestureRecognizer) {
-        if (menuControllerState == .opened) {
+
+    @objc private func didTapBackgroundView(_: UITapGestureRecognizer) {
+        if menuControllerState == .opened {
             toggleMenuView()
         }
-        if (themeSettingViewState == .opened) {
+        if themeSettingViewState == .opened {
             toggleThemeSettingView()
         }
     }
-    
+
     @objc private func didPanGestureActionInMenuView(_ sender: UIPanGestureRecognizer) {
         guard let menuView = menuController.view else { return }
         let translation = sender.translation(in: menuView)
         sender.setTranslation(CGPoint.zero, in: menuView)
-        
+
         if sender.state == .changed {
             guard (menuView.frame.origin.x + translation.x) <= 0 else { return }
-            
+
             menuView.frame.origin.x += translation.x
         }
-        
+
         let currentOrigin = menuView.frame.origin.x
         let halfOfWidth = menuView.frame.width / 2
-        
+
         if sender.state == .ended {
-            if (sender.velocity(in: menuView).x < -550) {
+            if sender.velocity(in: menuView).x < -550 {
                 toggleMenuView()
-            } else if (currentOrigin >= -(halfOfWidth)) {
+            } else if currentOrigin >= -halfOfWidth {
                 UIView.animate(withDuration: 0.6, delay: 0, usingSpringWithDamping: 0.92, initialSpringVelocity: 0, options: .curveEaseInOut) {
                     self.menuController.view.frame.origin.x = 0
                 }
@@ -353,16 +352,16 @@ extension STTimetableTabViewController {
             }
         }
     }
-    
+
     private func showBackgroundCoverView() {
         backgroundView.isHidden = false
-        backgroundView.frame.size.width = self.containerView.frame.size.width
-        backgroundView.frame.size.height = self.tabBarController!.view.frame.size.height
+        backgroundView.frame.size.width = containerView.frame.size.width
+        backgroundView.frame.size.height = tabBarController!.view.frame.size.height
         backgroundView.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
     }
-    
+
     private func hideBackgroundCoverView() {
-        if (themeSettingViewState == .opened) {
+        if themeSettingViewState == .opened {
             currentTimetable?.theme = originalTheme
             temporaryTheme = nil
             timetableView.reloadData()
@@ -370,28 +369,28 @@ extension STTimetableTabViewController {
         backgroundView.frame.size.width = 0
         backgroundView.isHidden = true
     }
-    
+
     private func toggleMenuView() {
         guard let menuController = menuController else { return }
         switch menuControllerState {
         case .closed:
             showBackgroundCoverView()
-            self.tabBarController!.view.addSubview(backgroundView)
-            self.tabBarController!.view.addSubview(menuController.view)
+            tabBarController!.view.addSubview(backgroundView)
+            tabBarController!.view.addSubview(menuController.view)
             self.menuController?.fetchTablelist()
             self.menuController?.view.isHidden = false
             UIView.animate(withDuration: 0.6, delay: 0, usingSpringWithDamping: 0.92, initialSpringVelocity: 0, options: .curveEaseInOut) {
                 menuController.view.frame.origin.x = 0
-                
-            } completion: { finished in
+
+            } completion: { _ in
                 self.menuControllerState = .opened
             }
-            
+
         case .opened:
-            self.hideBackgroundCoverView()
+            hideBackgroundCoverView()
             UIView.animate(withDuration: 0.32, delay: 0, options: .curveEaseInOut) {
                 menuController.view.frame.origin.x = -(self.containerView.frame.width)
-            } completion: { finished in
+            } completion: { _ in
                 menuController.view.isHidden = true
                 self.menuControllerState = .closed
             }
@@ -405,33 +404,33 @@ extension STTimetableTabViewController {
         //            themeSettingViewController?.delegate = self
         themeSettingController.setTemporaryTheme = setTemporaryTheme
         themeSettingController.setTheme = setTheme
-        
-        let key = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+
+        let key = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
         key?.addSubview(themeSettingController!.view)
         key?.bringSubviewToFront(themeSettingController!.view)
 
-        themeSettingController!.view.frame.size.width = self.tabBarController!.view.frame.width
-        themeSettingController!.view.frame.origin.y = self.tabBarController!.view.frame.height
+        themeSettingController!.view.frame.size.width = tabBarController!.view.frame.width
+        themeSettingController!.view.frame.origin.y = tabBarController!.view.frame.height
         themeSettingController!.view.layer.masksToBounds = true
         themeSettingController!.view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
     }
-    
+
     func toggleThemeSettingView() {
         switch themeSettingViewState {
         case .closed:
             showBackgroundCoverView()
             UIView.animate(withDuration: 0.6, delay: 0, usingSpringWithDamping: 0.92, initialSpringVelocity: 0, options: .curveEaseInOut) {
                 self.themeSettingController?.view.frame.origin.y = self.tabBarController!.view.frame.height - (self.themeSettingController?.view.frame.height ?? 0)
-                
-            } completion: { finished in
+
+            } completion: { _ in
                 self.themeSettingViewState = .opened
             }
-            
+
         case .opened:
             hideBackgroundCoverView()
             UIView.animate(withDuration: 0.32, delay: 0, options: .curveEaseInOut) {
                 self.themeSettingController?.view.frame.origin.y = self.tabBarController!.view.frame.height
-            } completion: { finished in
+            } completion: { _ in
                 self.themeSettingViewState = .closed
             }
         }
@@ -439,11 +438,12 @@ extension STTimetableTabViewController {
 }
 
 // MARK: Set noti navbar item
+
 extension STTimetableTabViewController {
     func setNotiBadge(_ shouldShowBadge: Bool) {
         let notiButton = rightBarButtonsForTimetable.last?.customView as? UIButton
-        
-        if (shouldShowBadge) {
+
+        if shouldShowBadge {
             let image = #imageLiteral(resourceName: "tabAlarmNotiOff").withRenderingMode(.alwaysOriginal)
             notiButton?.setImage(image, for: .normal)
         } else {
@@ -455,34 +455,32 @@ extension STTimetableTabViewController {
 }
 
 extension STTimetableTabViewController: MenuViewControllerDelegate {
-    
     func close(_: MenuViewController) {
         toggleMenuView()
     }
-    
-    func showThemeSettingView(_: MenuViewController, _ timetable: STTimetable) {
+
+    func showThemeSettingView(_: MenuViewController, _: STTimetable) {
         toggleThemeSettingView()
     }
-    
+
     private func setTemporaryTheme(_ theme: STTheme) {
         currentTimetable?.theme = theme
         temporaryTheme = theme
         timetableView.reloadData()
     }
-    
+
     private func setTheme() {
         if let timetable = currentTimetable, let id = timetable.id {
             guard let theme = temporaryTheme else {
                 return
             }
-            STNetworking.updateTheme(id: id, theme: theme.rawValue) { (timetable) in
+            STNetworking.updateTheme(id: id, theme: theme.rawValue) { timetable in
                 self.originalTheme = self.temporaryTheme
                 self.temporaryTheme = nil
                 STTimetableManager.sharedInstance.currentTimetable = timetable
                 self.toggleThemeSettingView()
                 self.timetableView.reloadData()
-            } failure: { (_) in
-                
+            } failure: { _ in
             }
         }
     }
@@ -500,12 +498,12 @@ extension STTimetableTabViewController {
 }
 
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertFromNSAttributedStringKey(_ input: NSAttributedString.Key) -> String {
+private func convertFromNSAttributedStringKey(_ input: NSAttributedString.Key) -> String {
     return input.rawValue
 }
 
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertToOptionalNSAttributedStringKeyDictionary(_ input: [String: Any]?) -> [NSAttributedString.Key: Any]? {
+private func convertToOptionalNSAttributedStringKeyDictionary(_ input: [String: Any]?) -> [NSAttributedString.Key: Any]? {
     guard let input = input else { return nil }
-    return Dictionary(uniqueKeysWithValues: input.map { key, value in (NSAttributedString.Key(rawValue: key), value)})
+    return Dictionary(uniqueKeysWithValues: input.map { key, value in (NSAttributedString.Key(rawValue: key), value) })
 }

--- a/SNUTT/STTimetableTabViewController.swift
+++ b/SNUTT/STTimetableTabViewController.swift
@@ -90,8 +90,6 @@ class STTimetableTabViewController: UIViewController {
         menuController = UIStoryboard(name: "Main", bundle: Bundle.main).instantiateViewController(withIdentifier: "MenuViewController") as! MenuViewController
         menuController.delegate = self
         
-        originalTheme = STTimetableManager.sharedInstance.currentTimetable?.theme
-        
         addMenuView()
         addThemeSettingView()
     }
@@ -475,7 +473,6 @@ extension STTimetableTabViewController: MenuViewControllerDelegate {
     private func setTheme() {
         if let timetable = currentTimetable, let id = timetable.id {
             guard let theme = temporaryTheme else {
-                self.toggleThemeSettingView()
                 return
             }
             STNetworking.updateTheme(id: id, theme: theme.rawValue) { (timetable) in
@@ -493,8 +490,9 @@ extension STTimetableTabViewController: MenuViewControllerDelegate {
 
 extension STTimetableTabViewController {
     private func fetchCurrentTimetable() {
-        STNetworking.getRecentTimetable({ timetable in
+        STNetworking.getRecentTimetable({ [weak self] timetable in
             STTimetableManager.sharedInstance.currentTimetable = timetable
+            self?.originalTheme = timetable?.theme
         }, failure: {
             STAlertView.showAlert(title: "시간표 로딩 실패", message: "시간표가 서버에 존재하지 않습니다.")
         })


### PR DESCRIPTION
## 수정 사항
- 시간표 테마를 변경할 때 "적용" 버튼을 누르지 않고 회색 화면을 탭하여 시간표 테마 정하기에서 빠져나갈 경우 원래 테마가 아니라 기본 테마가 적용되는 문제가 있었습니다. (앱을 재시작하면 정상 작동합니다)
- 메뉴탭에서 시간표를 변경했을 때 `originalTheme`의 값이 업데이트되지 않아 발생한 문제였습니다.
- `hidesBackgroundCoverView()`에서 originalTheme을 설정하도록 하는 코드를 추가했습니다.