### PR TITLE
Fix transparent tabBar issue [SNUTT-400]

### DIFF
--- a/SNUTT/SNUTT/AppDelegate.swift
+++ b/SNUTT/SNUTT/AppDelegate.swift
@@ -127,6 +127,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let tabBarAppearance = UITabBarAppearance()
             tabBarAppearance.configureWithOpaqueBackground()
             tabBarAppearance.backgroundColor = .systemBackground
+            UITabBar.appearance().standardAppearance = tabBarAppearance
             UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
         }
     }


### PR DESCRIPTION
## 수정사항
- 탭바의 StandardAppearance 설정을 추가하였습니다. iOS 15부터는 기본적으로 탭바가 transparent하게 설정되어 발생하는 문제였습니다.