### PR TITLE
강의 목록에서 긴 강의명의 UI 깨짐 현상 해결 [SNUTT-423]

### DIFF
--- a/SNUTT/SNUTT/STLectureTableViewCell.xib
+++ b/SNUTT/SNUTT/STLectureTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -87,7 +87,7 @@
                         <constraint firstItem="RzP-ao-rwe" firstAttribute="leading" secondItem="ZPP-7X-0gh" secondAttribute="leading" constant="20" id="54E-In-7iq"/>
                         <constraint firstItem="GlS-Ab-fKd" firstAttribute="top" secondItem="RzP-ao-rwe" secondAttribute="bottom" constant="8" id="9Rk-h8-mVJ"/>
                         <constraint firstItem="mwB-IM-Xx4" firstAttribute="top" secondItem="ig6-I6-dTL" secondAttribute="bottom" constant="8" id="C9U-5f-d7a"/>
-                        <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="ig6-I6-dTL" secondAttribute="trailing" multiplier="2" priority="751" id="FIz-PT-pK9"/>
+                        <constraint firstItem="NW6-9Y-Czf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ig6-I6-dTL" secondAttribute="trailing" priority="751" constant="4" id="FIz-PT-pK9"/>
                         <constraint firstItem="ggO-3G-c9b" firstAttribute="centerY" secondItem="RzP-ao-rwe" secondAttribute="centerY" id="OtM-c6-yGQ"/>
                         <constraint firstItem="ig6-I6-dTL" firstAttribute="leading" secondItem="ZPP-7X-0gh" secondAttribute="leading" constant="20" id="QYa-8e-DO1"/>
                         <constraint firstAttribute="trailing" secondItem="NW6-9Y-Czf" secondAttribute="trailing" constant="20" id="ZID-Ve-6aB"/>


### PR DESCRIPTION
## 수정사항
- 강의명 label의 trailing을 `-학점` 라벨의 leading 기준으로 하도록 변경하였습니다.