### PR TITLE
ViewModel에서 함수만 넘기도록 변경

### DIFF
--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BE1D2B38280142EB008F9134 /* TimetableGridLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1D2B37280142EB008F9134 /* TimetableGridLayer.swift */; };
 		BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1D2B3928014527008F9134 /* Weekday.swift */; };
+		BE46B131282F95C90032EF82 /* TimetableLectureBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE46B130282F95C90032EF82 /* TimetableLectureBlocks.swift */; };
 		BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */; };
 		BE7E230327FF3C38004DC202 /* NavBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7E230227FF3C38004DC202 /* NavBarButton.swift */; };
 		BE982FB8281D0B33005F71E6 /* TimetableBlocksLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */; };
@@ -56,6 +57,7 @@
 /* Begin PBXFileReference section */
 		BE1D2B37280142EB008F9134 /* TimetableGridLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableGridLayer.swift; sourceTree = "<group>"; };
 		BE1D2B3928014527008F9134 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
+		BE46B130282F95C90032EF82 /* TimetableLectureBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableLectureBlocks.swift; sourceTree = "<group>"; };
 		BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTimetableScene.swift; sourceTree = "<group>"; };
 		BE7E230227FF3C38004DC202 /* NavBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavBarButton.swift; sourceTree = "<group>"; };
 		BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableBlocksLayer.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 			children = (
 				BE982FBF281D762F005F71E6 /* TimetableZStack.swift */,
 				BE982FBD281D6244005F71E6 /* TimetableBlock.swift */,
+				BE46B130282F95C90032EF82 /* TimetableLectureBlocks.swift */,
 				BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */,
 				BE1D2B37280142EB008F9134 /* TimetableGridLayer.swift */,
 			);
@@ -414,6 +417,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BEDF506D27EB740F00CDCC13 /* LectureList.swift in Sources */,
+				BE46B131282F95C90032EF82 /* TimetableLectureBlocks.swift in Sources */,
 				BEDF507727F42D1100CDCC13 /* STFont.swift in Sources */,
 				BEDF507327F427FA00CDCC13 /* MyLectureListScene.swift in Sources */,
 				BE7E230327FF3C38004DC202 /* NavBarButton.swift in Sources */,

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TimetableBlocksLayer: View {
-    
     let lectures: [Lecture]
     let getOffset: (_ of: TimePlace, _ in: CGSize) -> CGPoint?
     let getWeekWidth: (_ in: CGSize) -> CGFloat
@@ -23,7 +22,7 @@ struct TimetableBlocksLayer: View {
     }
 }
 
-//struct TimetableBlocks_Previews: PreviewProvider {
+// struct TimetableBlocks_Previews: PreviewProvider {
 //    static var previews: some View {
 //        ZStack {
 //            let viewModel = TimetableViewModel()
@@ -31,4 +30,4 @@ struct TimetableBlocksLayer: View {
 //            TimetableGridLayer(viewModel: viewModel)
 //        }
 //    }
-//}
+// }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -8,29 +8,27 @@
 import SwiftUI
 
 struct TimetableBlocksLayer: View {
-    let viewModel: TimetableViewModel
+    
+    let lectures: [Lecture]
+    let getOffset: (_ of: TimePlace, _ in: CGSize) -> CGPoint?
+    let getWeekWidth: (_ in: CGSize) -> CGFloat
+    let getHeight: (_ of: TimePlace, _ in: CGSize) -> CGFloat
 
     var body: some View {
         GeometryReader { reader in
-            ForEach(viewModel.lectures) { lecture in
-                ForEach(lecture.timePlaces) { timePlace in
-                    if let offsetPoint = viewModel.getOffset(of: timePlace, in: reader.size) {
-                        TimetableBlock(lecture: lecture, timePlace: timePlace)
-                            .frame(width: viewModel.getWeekWidth(in: reader.size), height: viewModel.getHeight(of: timePlace, in: reader.size), alignment: .center)
-                            .offset(x: offsetPoint.x, y: offsetPoint.y)
-                    }
-                }
+            ForEach(lectures) { lecture in
+                TimetableLectureBlocks(lecture: lecture, timetableSize: reader.size, getOffset: getOffset, getWeekWidth: getWeekWidth, getHeight: getHeight)
             }
         }
     }
 }
 
-struct TimetableBlocks_Previews: PreviewProvider {
-    static var previews: some View {
-        ZStack {
-            let viewModel = TimetableViewModel()
-            TimetableBlocksLayer(viewModel: viewModel)
-            TimetableGridLayer(viewModel: viewModel)
-        }
-    }
-}
+//struct TimetableBlocks_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ZStack {
+//            let viewModel = TimetableViewModel()
+//            TimetableBlocksLayer(viewModel: viewModel)
+//            TimetableGridLayer(viewModel: viewModel)
+//        }
+//    }
+//}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableLectureBlocks.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableLectureBlocks.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct TimetableLectureBlocks: View {
     let lecture: Lecture
     let timetableSize: CGSize
-    
+
     let getOffset: (_ of: TimePlace, _ in: CGSize) -> CGPoint?
     let getWeekWidth: (_ in: CGSize) -> CGFloat
     let getHeight: (_ of: TimePlace, _ in: CGSize) -> CGFloat
-    
+
     var body: some View {
         ForEach(lecture.timePlaces) { timePlace in
             if let offsetPoint = getOffset(timePlace, timetableSize) {
@@ -26,8 +26,8 @@ struct TimetableLectureBlocks: View {
     }
 }
 
-//struct TimetableLectureBlocks_Previews: PreviewProvider {
+// struct TimetableLectureBlocks_Previews: PreviewProvider {
 //    static var previews: some View {
 //        TimetableLectureBlocks()
 //    }
-//}
+// }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableLectureBlocks.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableLectureBlocks.swift
@@ -1,0 +1,33 @@
+//
+//  TimetableLectureBlocks.swift
+//  SNUTT
+//
+//  Created by 박신홍 on 2022/05/14.
+//
+
+import SwiftUI
+
+struct TimetableLectureBlocks: View {
+    let lecture: Lecture
+    let timetableSize: CGSize
+    
+    let getOffset: (_ of: TimePlace, _ in: CGSize) -> CGPoint?
+    let getWeekWidth: (_ in: CGSize) -> CGFloat
+    let getHeight: (_ of: TimePlace, _ in: CGSize) -> CGFloat
+    
+    var body: some View {
+        ForEach(lecture.timePlaces) { timePlace in
+            if let offsetPoint = getOffset(timePlace, timetableSize) {
+                TimetableBlock(lecture: lecture, timePlace: timePlace)
+                    .frame(width: getWeekWidth(timetableSize), height: getHeight(timePlace, timetableSize), alignment: .center)
+                    .offset(x: offsetPoint.x, y: offsetPoint.y)
+            }
+        }
+    }
+}
+
+//struct TimetableLectureBlocks_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TimetableLectureBlocks()
+//    }
+//}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
@@ -12,7 +12,7 @@ struct TimetableZStack: View {
     var body: some View {
         ZStack {
             TimetableGridLayer(viewModel: viewModel)
-            TimetableBlocksLayer(viewModel: viewModel)
+            TimetableBlocksLayer(lectures: viewModel.lectures, getOffset: viewModel.getOffset, getWeekWidth: viewModel.getWeekWidth, getHeight: viewModel.getHeight)
         }
     }
 }


### PR DESCRIPTION
### 프로토타입입니다.

- `TimetableBlocksLayer`를 포함한 자식 뷰들이 `viewModel`을 받지 않고 꼭 필요한 함수와 변수들만 전달받도록 변경했습니다. 
- 그런데 Swift에서는 함수를 넘기는 방식이 자바스크립트만큼 매끄럽지는 않은 것 같습니다. 함수를 `func`로 정의할때는 인자에 라벨을 붙여주는 게 가능했는데, 변수로 선언할 때에는 다 지워주어야 하는 것 같습니다.

```swift
viewModel.getHeight(of: timePlace, in: timetableSize)
self.getHeight(timePlace, timetableSize)
```

- 아래와 같이 함수가 필요한 View마다 함수 프로토타입을 중복으로 선언해주어야 하는 문제가 있었습니다.

```swift
// in TimetableLectureBlocks.swift, TimetableBlocksLayer.swift, TimetableGridLayer.swift
// line order is important!
let getOffset: (_ of: TimePlace, _ in: CGSize) -> CGPoint?
let getWeekWidth: (_ in: CGSize) -> CGFloat
let getHeight: (_ of: TimePlace, _ in: CGSize) -> CGFloat
```

- 함수를 새롭게 선언하는 방식이다보니, 원본 함수의 시그니처가 조금만 바뀌어도 한 번에 리팩토링이 불가능하고 위 정의들을 다 찾아다니면서 바꿔주어야 하는 문제도 있습니다. 원본 함수에 docstring으로 달아두었던 주석도 보이지 않구요.
- 하위 뷰에서 새로운 기능이 추가되어 새로운 함수가 필요해진다면, 중간 뷰까지 다 수정해서 prop drilling을 해주어야 합니다.

직접 해보니 함수형으로 짜는건 swift에는 좀 안맞지 않나 하는 생각이 드네요..