### PR TITLE
실제 강의 시간은 수정하지 못하도록 변경 [SNUTT-445]

### DIFF
--- a/SNUTT/SNUTT/STSingleClassTableViewCell.swift
+++ b/SNUTT/SNUTT/STSingleClassTableViewCell.swift
@@ -29,7 +29,6 @@ class STSingleClassTableViewCell: STLectureDetailTableViewCell, UITextFieldDeleg
         }
     }
 
-    var custom: Bool = false
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -71,9 +70,9 @@ class STSingleClassTableViewCell: STLectureDetailTableViewCell, UITextFieldDeleg
 
     override func setEditable(_ editable: Bool) {
         placeTextField.isEnabled = editable
-        timeTextField.isEnabled = custom && editable
-        deleteBtn.isHidden = !(custom && editable)
-        if editable, !custom {
+        timeTextField.isEnabled = customLecture && editable
+        deleteBtn.isHidden = !(customLecture && editable)
+        if editable, !customLecture {
             timeTextField.textColor = UIColor(white: 0.67, alpha: 1.0)
         } else {
             timeTextField.textColor = UIColor(white: 0.0, alpha: 1.0)

--- a/SNUTT/SNUTT/STSingleLectureTableViewController.swift
+++ b/SNUTT/SNUTT/STSingleLectureTableViewController.swift
@@ -282,11 +282,10 @@ class STSingleLectureTableViewController: UITableViewController {
             return tmpCell
         case .singleClass:
             let cell = tmpCell as! STSingleClassTableViewCell
-            cell.customLecture = currentLecture.isCustomLecture // order matters
+            cell.customLecture = currentLecture.isCustomLecture
             cell.singleClass = currentLecture.classList[indexPath.row - 1]
             cell.placeDoneBlock = { value in self.currentLecture.classList[indexPath.row - 1].place = value }
             cell.timeDoneBlock = { value in self.currentLecture.classList[indexPath.row - 1].time = value }
-            cell.custom = true // Single Class Editable in non-custom
             cell.deleteLectureBlock = {
                 guard let indexPathNow = self.tableView.indexPath(for: cell) else {
                     return


### PR DESCRIPTION
# 수정 내용

- 기존에 있던 `custom`이라는 필드를 보면 원래 실제 강의는 수정 못하도록 되어 있었던 것 같은데, 왜인진 모르겠지만 이 값이 무조건 `true`로 설정되어 있었습니다.
- 그래서 해당 로직이 잘 작동하도록 `custom` 필드를 `customLecture`로 교체해주었습니다.