### PR TITLE
Fix data flow with AppState [SNUTT-456]

### DIFF
--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		DC2915A128660FBB00FE5F9A /* ReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A028660FBB00FE5F9A /* ReviewViewModel.swift */; };
 		DC2915A32866958100FE5F9A /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A22866958100FE5F9A /* User.swift */; };
 		DC2915A52866980B00FE5F9A /* Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A42866980B00FE5F9A /* Setting.swift */; };
-		DC2915A72866984000FE5F9A /* DrawingSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A62866984000FE5F9A /* DrawingSetting.swift */; };
+		DC2915A72866984000FE5F9A /* TimetableSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A62866984000FE5F9A /* TimetableSetting.swift */; };
 		DC2915A92866986600FE5F9A /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A82866986600FE5F9A /* System.swift */; };
 		DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC860F4827E5C87D0068C94B /* SNUTTApp.swift */; };
 		DC860F4D27E5C87F0068C94B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC860F4C27E5C87F0068C94B /* Assets.xcassets */; };
@@ -87,7 +87,7 @@
 		DC2915A028660FBB00FE5F9A /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
 		DC2915A22866958100FE5F9A /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		DC2915A42866980B00FE5F9A /* Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Setting.swift; sourceTree = "<group>"; };
-		DC2915A62866984000FE5F9A /* DrawingSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingSetting.swift; sourceTree = "<group>"; };
+		DC2915A62866984000FE5F9A /* TimetableSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableSetting.swift; sourceTree = "<group>"; };
 		DC2915A82866986600FE5F9A /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
 		DC860F4527E5C87D0068C94B /* SNUTT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SNUTT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC860F4827E5C87D0068C94B /* SNUTTApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNUTTApp.swift; sourceTree = "<group>"; };
@@ -211,7 +211,7 @@
 				BE1D2B3928014527008F9134 /* Weekday.swift */,
 				DC2915A22866958100FE5F9A /* User.swift */,
 				DC2915A42866980B00FE5F9A /* Setting.swift */,
-				DC2915A62866984000FE5F9A /* DrawingSetting.swift */,
+				DC2915A62866984000FE5F9A /* TimetableSetting.swift */,
 				DC2915A82866986600FE5F9A /* System.swift */,
 			);
 			path = Models;
@@ -472,7 +472,7 @@
 				DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */,
 				BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */,
 				DCD41A7227E5CE1D00CF380E /* TimetableViewModel.swift in Sources */,
-				DC2915A72866984000FE5F9A /* DrawingSetting.swift in Sources */,
+				DC2915A72866984000FE5F9A /* TimetableSetting.swift in Sources */,
 				BEDF507927F42D7500CDCC13 /* STColor.swift in Sources */,
 				DCD41A6A27E5CD8700CF380E /* TimetableApi.swift in Sources */,
 			);

--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B87431CB283B5A7300D78C59 /* SNUTTViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87431CA283B5A7300D78C59 /* SNUTTViewModel.swift */; };
 		BE1D2B38280142EB008F9134 /* TimetableGridLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1D2B37280142EB008F9134 /* TimetableGridLayer.swift */; };
 		BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1D2B3928014527008F9134 /* Weekday.swift */; };
-		B87431CB283B5A7300D78C59 /* SNUTTViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87431CA283B5A7300D78C59 /* SNUTTViewModel.swift */; };
 		BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */; };
 		BE7E230327FF3C38004DC202 /* NavBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7E230227FF3C38004DC202 /* NavBarButton.swift */; };
 		BE982FB8281D0B33005F71E6 /* TimetableBlocksLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */; };
@@ -23,6 +23,11 @@
 		BEDF507527F4289B00CDCC13 /* Lecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507427F4289B00CDCC13 /* Lecture.swift */; };
 		BEDF507727F42D1100CDCC13 /* STFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507627F42D1100CDCC13 /* STFont.swift */; };
 		BEDF507927F42D7500CDCC13 /* STColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507827F42D7500CDCC13 /* STColor.swift */; };
+		DC2915992865D69700FE5F9A /* MyLectureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915982865D69700FE5F9A /* MyLectureListViewModel.swift */; };
+		DC29159B2865F95100FE5F9A /* SettingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159A2865F95100FE5F9A /* SettingScene.swift */; };
+		DC29159D2865FA2800FE5F9A /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */; };
+		DC29159F28660F7800FE5F9A /* ReviewScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159E28660F7800FE5F9A /* ReviewScene.swift */; };
+		DC2915A128660FBB00FE5F9A /* ReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A028660FBB00FE5F9A /* ReviewViewModel.swift */; };
 		DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC860F4827E5C87D0068C94B /* SNUTTApp.swift */; };
 		DC860F4D27E5C87F0068C94B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC860F4C27E5C87F0068C94B /* Assets.xcassets */; };
 		DC860F5027E5C87F0068C94B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC860F4F27E5C87F0068C94B /* Preview Assets.xcassets */; };
@@ -55,9 +60,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B87431CA283B5A7300D78C59 /* SNUTTViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNUTTViewModel.swift; sourceTree = "<group>"; };
 		BE1D2B37280142EB008F9134 /* TimetableGridLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableGridLayer.swift; sourceTree = "<group>"; };
 		BE1D2B3928014527008F9134 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
-		B87431CA283B5A7300D78C59 /* SNUTTViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNUTTViewModel.swift; sourceTree = "<group>"; };
 		BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTimetableScene.swift; sourceTree = "<group>"; };
 		BE7E230227FF3C38004DC202 /* NavBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavBarButton.swift; sourceTree = "<group>"; };
 		BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableBlocksLayer.swift; sourceTree = "<group>"; };
@@ -71,6 +76,11 @@
 		BEDF507427F4289B00CDCC13 /* Lecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lecture.swift; sourceTree = "<group>"; };
 		BEDF507627F42D1100CDCC13 /* STFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STFont.swift; sourceTree = "<group>"; };
 		BEDF507827F42D7500CDCC13 /* STColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STColor.swift; sourceTree = "<group>"; };
+		DC2915982865D69700FE5F9A /* MyLectureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLectureListViewModel.swift; sourceTree = "<group>"; };
+		DC29159A2865F95100FE5F9A /* SettingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingScene.swift; sourceTree = "<group>"; };
+		DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		DC29159E28660F7800FE5F9A /* ReviewScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScene.swift; sourceTree = "<group>"; };
+		DC2915A028660FBB00FE5F9A /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
 		DC860F4527E5C87D0068C94B /* SNUTT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SNUTT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC860F4827E5C87D0068C94B /* SNUTTApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNUTTApp.swift; sourceTree = "<group>"; };
 		DC860F4C27E5C87F0068C94B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -243,6 +253,8 @@
 			children = (
 				BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */,
 				BEDF507227F427FA00CDCC13 /* MyLectureListScene.swift */,
+				DC29159A2865F95100FE5F9A /* SettingScene.swift */,
+				DC29159E28660F7800FE5F9A /* ReviewScene.swift */,
 			);
 			path = Scenes;
 			sourceTree = "<group>";
@@ -264,6 +276,9 @@
 			children = (
 				B87431CA283B5A7300D78C59 /* SNUTTViewModel.swift */,
 				DCD41A7127E5CE1D00CF380E /* TimetableViewModel.swift */,
+				DC2915982865D69700FE5F9A /* MyLectureListViewModel.swift */,
+				DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */,
+				DC2915A028660FBB00FE5F9A /* ReviewViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -418,7 +433,10 @@
 			files = (
 				BEDF506D27EB740F00CDCC13 /* LectureList.swift in Sources */,
 				BEDF507727F42D1100CDCC13 /* STFont.swift in Sources */,
+				DC2915A128660FBB00FE5F9A /* ReviewViewModel.swift in Sources */,
 				BEDF507327F427FA00CDCC13 /* MyLectureListScene.swift in Sources */,
+				DC29159D2865FA2800FE5F9A /* SettingViewModel.swift in Sources */,
+				DC29159B2865F95100FE5F9A /* SettingScene.swift in Sources */,
 				BE7E230327FF3C38004DC202 /* NavBarButton.swift in Sources */,
 				BEDF506F27EB744A00CDCC13 /* LectureDetails.swift in Sources */,
 				BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */,
@@ -433,6 +451,8 @@
 				BE982FB8281D0B33005F71E6 /* TimetableBlocksLayer.swift in Sources */,
 				BE1D2B38280142EB008F9134 /* TimetableGridLayer.swift in Sources */,
 				DCD41A7527E5CEA500CF380E /* AppState.swift in Sources */,
+				DC29159F28660F7800FE5F9A /* ReviewScene.swift in Sources */,
+				DC2915992865D69700FE5F9A /* MyLectureListViewModel.swift in Sources */,
 				BE982FBE281D6244005F71E6 /* TimetableBlock.swift in Sources */,
 				DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */,
 				BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */,

--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -28,6 +28,10 @@
 		DC29159D2865FA2800FE5F9A /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */; };
 		DC29159F28660F7800FE5F9A /* ReviewScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159E28660F7800FE5F9A /* ReviewScene.swift */; };
 		DC2915A128660FBB00FE5F9A /* ReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A028660FBB00FE5F9A /* ReviewViewModel.swift */; };
+		DC2915A32866958100FE5F9A /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A22866958100FE5F9A /* User.swift */; };
+		DC2915A52866980B00FE5F9A /* Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A42866980B00FE5F9A /* Setting.swift */; };
+		DC2915A72866984000FE5F9A /* DrawingSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A62866984000FE5F9A /* DrawingSetting.swift */; };
+		DC2915A92866986600FE5F9A /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915A82866986600FE5F9A /* System.swift */; };
 		DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC860F4827E5C87D0068C94B /* SNUTTApp.swift */; };
 		DC860F4D27E5C87F0068C94B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC860F4C27E5C87F0068C94B /* Assets.xcassets */; };
 		DC860F5027E5C87F0068C94B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC860F4F27E5C87F0068C94B /* Preview Assets.xcassets */; };
@@ -81,6 +85,10 @@
 		DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		DC29159E28660F7800FE5F9A /* ReviewScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScene.swift; sourceTree = "<group>"; };
 		DC2915A028660FBB00FE5F9A /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
+		DC2915A22866958100FE5F9A /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		DC2915A42866980B00FE5F9A /* Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Setting.swift; sourceTree = "<group>"; };
+		DC2915A62866984000FE5F9A /* DrawingSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingSetting.swift; sourceTree = "<group>"; };
+		DC2915A82866986600FE5F9A /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
 		DC860F4527E5C87D0068C94B /* SNUTT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SNUTT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC860F4827E5C87D0068C94B /* SNUTTApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNUTTApp.swift; sourceTree = "<group>"; };
 		DC860F4C27E5C87F0068C94B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -201,6 +209,10 @@
 				BE982FBB281D5227005F71E6 /* TimePlace.swift */,
 				BEDF507427F4289B00CDCC13 /* Lecture.swift */,
 				BE1D2B3928014527008F9134 /* Weekday.swift */,
+				DC2915A22866958100FE5F9A /* User.swift */,
+				DC2915A42866980B00FE5F9A /* Setting.swift */,
+				DC2915A62866984000FE5F9A /* DrawingSetting.swift */,
+				DC2915A82866986600FE5F9A /* System.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -439,9 +451,11 @@
 				DC29159B2865F95100FE5F9A /* SettingScene.swift in Sources */,
 				BE7E230327FF3C38004DC202 /* NavBarButton.swift in Sources */,
 				BEDF506F27EB744A00CDCC13 /* LectureDetails.swift in Sources */,
+				DC2915A32866958100FE5F9A /* User.swift in Sources */,
 				BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */,
 				DCD41A6027E5CC7700CF380E /* Timetable.swift in Sources */,
 				B87431CB283B5A7300D78C59 /* SNUTTViewModel.swift in Sources */,
+				DC2915A92866986600FE5F9A /* System.swift in Sources */,
 				BEDF507527F4289B00CDCC13 /* Lecture.swift in Sources */,
 				DCD41A6827E5CD2A00CF380E /* UserDefaults.swift in Sources */,
 				DCD41A6327E5CCD500CF380E /* TimetableService.swift in Sources */,
@@ -450,6 +464,7 @@
 				BEDF506B27EB73EE00CDCC13 /* LectureListCell.swift in Sources */,
 				BE982FB8281D0B33005F71E6 /* TimetableBlocksLayer.swift in Sources */,
 				BE1D2B38280142EB008F9134 /* TimetableGridLayer.swift in Sources */,
+				DC2915A52866980B00FE5F9A /* Setting.swift in Sources */,
 				DCD41A7527E5CEA500CF380E /* AppState.swift in Sources */,
 				DC29159F28660F7800FE5F9A /* ReviewScene.swift in Sources */,
 				DC2915992865D69700FE5F9A /* MyLectureListViewModel.swift in Sources */,
@@ -457,6 +472,7 @@
 				DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */,
 				BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */,
 				DCD41A7227E5CE1D00CF380E /* TimetableViewModel.swift in Sources */,
+				DC2915A72866984000FE5F9A /* DrawingSetting.swift in Sources */,
 				BEDF507927F42D7500CDCC13 /* STColor.swift in Sources */,
 				DCD41A6A27E5CD8700CF380E /* TimetableApi.swift in Sources */,
 			);

--- a/SNUTT-2022/SNUTT.xcworkspace/contents.xcworkspacedata
+++ b/SNUTT-2022/SNUTT.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:SNUTT.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/SNUTT-2022/SNUTT.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SNUTT-2022/SNUTT.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -9,43 +9,15 @@ import Combine
 import SwiftUI
 
 class AppState: ObservableObject {
-    @Published var currentUser = CurrentUser()
-    @Published var currentTimetable = CurrentTimetable()
+    @Published var currentUser = User()
+    @Published var currentTimetable = Timetable(lectures: [])
     @Published var setting = Setting()
     @Published var system = System()
     
     @Published var selectedTab: SelectedTab = .timetable
-}
-
-extension AppState {
-    enum SelectedTab {
-        case timetable
-        case search
-        case review
-        case settings
-    }
     
-    enum State {
-        case error
-        case success
-    }
-}
-
-extension AppState {
-    class CurrentUser: ObservableObject {
-        // var user = User()             // User Model 생성 후 주석 해제
-        var token: String?
-        var userId: String?
-        var registeredFCMToken: String?
-    }
-}
-
-extension AppState {
-    class CurrentTimetable: ObservableObject {
-        var timetable = Timetable()
-        
-        // for test(will be removed)
-        var lectures = [
+    init() {
+        let mockLectures = [
             Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
                 TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
                 TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
@@ -56,45 +28,16 @@ extension AppState {
                 TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
             ]),
         ]
+        
+        currentTimetable.lectures = mockLectures
     }
 }
 
-// 현재 환경설정 관련 정보(STDefaults)
 extension AppState {
-    class Setting: ObservableObject {
-        var autoFit: Bool = true
-        var dayRange: [Int] = [0, 4]
-        var timeRange: [Double] = [0.0, 14.0]
-        var shouldShowBadge: Bool = false
-        var appVersion: String?
-        var apiKey: String?
-        var shouldDeleteFCMInfos: String? // STFCMInfoList
-        var colorList: String? // STColorList
-        var snuevWebUrl: String?
-        
-        var drawing: DrawingSetting = DrawingSetting()
-    }
-    
-    class DrawingSetting: ObservableObject {
-        let minHour: Int = 8
-        let maxHour: Int = 19
-        
-        let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
-        
-        var hourCount: Int {
-            maxHour - minHour + 1
-        }
-        
-        var weekCount: Int {
-            visibleWeeks.count
-        }
-    }
-}
-
-// 시스템 상태
-extension AppState {
-    struct System {
-        var showActivityIndicator = false
-        var state: State = .success
+    enum SelectedTab {
+        case timetable
+        case search
+        case review
+        case settings
     }
 }

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -13,7 +13,7 @@ class AppState {
     var currentTimetable = Timetable(lectures: [])
     var setting = Setting()
     var system = System()
-    
+
     init() {
         let mockLectures = [
             Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
@@ -26,7 +26,7 @@ class AppState {
                 TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
             ]),
         ]
-        
+
         currentTimetable.lectures = mockLectures
     }
 }

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -13,7 +13,7 @@ class AppState: ObservableObject {
     @Published var currentTimetable = CurrentTimetable()
     @Published var setting = Setting()
     @Published var system = System()
-
+    
     @Published var selectedTab: SelectedTab = .timetable
 }
 
@@ -24,7 +24,7 @@ extension AppState {
         case review
         case settings
     }
-
+    
     enum State {
         case error
         case success
@@ -32,7 +32,7 @@ extension AppState {
 }
 
 extension AppState {
-    struct CurrentUser {
+    class CurrentUser: ObservableObject {
         // var user = User()             // User Model 생성 후 주석 해제
         var token: String?
         var userId: String?
@@ -41,11 +41,11 @@ extension AppState {
 }
 
 extension AppState {
-    struct CurrentTimetable {
+    class CurrentTimetable: ObservableObject {
         var timetable = Timetable()
-
+        
         // for test(will be removed)
-        let lectures = [
+        var lectures = [
             Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
                 TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
                 TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
@@ -56,15 +56,12 @@ extension AppState {
                 TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
             ]),
         ]
-        var dummyLecture: Lecture {
-            lectures[0]
-        }
     }
 }
 
 // 현재 환경설정 관련 정보(STDefaults)
 extension AppState {
-    struct Setting {
+    class Setting: ObservableObject {
         var autoFit: Bool = true
         var dayRange: [Int] = [0, 4]
         var timeRange: [Double] = [0.0, 14.0]
@@ -74,6 +71,23 @@ extension AppState {
         var shouldDeleteFCMInfos: String? // STFCMInfoList
         var colorList: String? // STColorList
         var snuevWebUrl: String?
+        
+        var drawing: DrawingSetting = DrawingSetting()
+    }
+    
+    class DrawingSetting: ObservableObject {
+        let minHour: Int = 8
+        let maxHour: Int = 19
+        
+        let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
+        
+        var hourCount: Int {
+            maxHour - minHour + 1
+        }
+        
+        var weekCount: Int {
+            visibleWeeks.count
+        }
     }
 }
 
@@ -82,34 +96,5 @@ extension AppState {
     struct System {
         var showActivityIndicator = false
         var state: State = .success
-    }
-}
-
-// if needed
-// extension AppState: Equatable {
-//    static func == (lhs: AppState, rhs: AppState) -> Bool {
-//        //return lhs.currentTimetable == rhs.currentTimetable
-//        return true
-//    }
-// }
-
-/// For demo purpose. To be removed.
-class DummyAppState {
-    static let shared = DummyAppState()
-
-    let lectures = [
-        Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
-            TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 3)!, start: 4.70, len: 1.5, place: "302-123"),
-        ]),
-        Lecture(id: 2, title: "컴퓨터구조", instructor: "김진수", timePlaces: [
-            TimePlace(day: Weekday(rawValue: 2)!, start: 7.5, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
-        ]),
-    ]
-
-    var dummyLecture: Lecture {
-        lectures[0]
     }
 }

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -14,8 +14,6 @@ class AppState: ObservableObject {
     @Published var setting = Setting()
     @Published var system = System()
     
-    @Published var selectedTab: SelectedTab = .timetable
-    
     init() {
         let mockLectures = [
             Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
@@ -30,14 +28,5 @@ class AppState: ObservableObject {
         ]
         
         currentTimetable.lectures = mockLectures
-    }
-}
-
-extension AppState {
-    enum SelectedTab {
-        case timetable
-        case search
-        case review
-        case settings
     }
 }

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -8,11 +8,11 @@
 import Combine
 import SwiftUI
 
-class AppState: ObservableObject {
-    @Published var currentUser = User()
-    @Published var currentTimetable = Timetable(lectures: [])
-    @Published var setting = Setting()
-    @Published var system = System()
+class AppState {
+    var currentUser = User()
+    var currentTimetable = Timetable(lectures: [])
+    var setting = Setting()
+    var system = System()
     
     init() {
         let mockLectures = [

--- a/SNUTT-2022/SNUTT/Models/DrawingSetting.swift
+++ b/SNUTT-2022/SNUTT/Models/DrawingSetting.swift
@@ -1,0 +1,23 @@
+//
+//  DrawingSetting.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/25.
+//
+
+import SwiftUI
+
+class DrawingSetting: ObservableObject {
+    let minHour: Int = 8
+    let maxHour: Int = 19
+    
+    let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
+    
+    var hourCount: Int {
+        maxHour - minHour + 1
+    }
+    
+    var weekCount: Int {
+        visibleWeeks.count
+    }
+}

--- a/SNUTT-2022/SNUTT/Models/Setting.swift
+++ b/SNUTT-2022/SNUTT/Models/Setting.swift
@@ -1,0 +1,22 @@
+//
+//  Setting.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/25.
+//
+
+import SwiftUI
+
+class Setting: ObservableObject {
+    var autoFit: Bool = true
+    var dayRange: [Int] = [0, 4]
+    var timeRange: [Double] = [0.0, 14.0]
+    var shouldShowBadge: Bool = false
+    var appVersion: String?
+    var apiKey: String?
+    var shouldDeleteFCMInfos: String? // STFCMInfoList
+    var colorList: String? // STColorList
+    var snuevWebUrl: String?
+    
+    var drawing: DrawingSetting = DrawingSetting()
+}

--- a/SNUTT-2022/SNUTT/Models/Setting.swift
+++ b/SNUTT-2022/SNUTT/Models/Setting.swift
@@ -18,5 +18,5 @@ class Setting: ObservableObject {
     var colorList: String? // STColorList
     var snuevWebUrl: String?
     
-    var drawing: DrawingSetting = DrawingSetting()
+    var drawing: TimetableSetting = TimetableSetting()
 }

--- a/SNUTT-2022/SNUTT/Models/Setting.swift
+++ b/SNUTT-2022/SNUTT/Models/Setting.swift
@@ -17,6 +17,6 @@ class Setting: ObservableObject {
     var shouldDeleteFCMInfos: String? // STFCMInfoList
     var colorList: String? // STColorList
     var snuevWebUrl: String?
-    
-    var drawing: TimetableSetting = TimetableSetting()
+
+    var drawing: TimetableSetting = .init()
 }

--- a/SNUTT-2022/SNUTT/Models/System.swift
+++ b/SNUTT-2022/SNUTT/Models/System.swift
@@ -1,0 +1,18 @@
+//
+//  System.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/25.
+//
+
+import Foundation
+
+struct System {
+    enum State {
+        case error
+        case success
+    }
+    
+    var showActivityIndicator = false
+    var state: State = .success
+}

--- a/SNUTT-2022/SNUTT/Models/System.swift
+++ b/SNUTT-2022/SNUTT/Models/System.swift
@@ -12,7 +12,7 @@ struct System {
         case error
         case success
     }
-    
+
     var showActivityIndicator = false
     var state: State = .success
 }

--- a/SNUTT-2022/SNUTT/Models/Timetable.swift
+++ b/SNUTT-2022/SNUTT/Models/Timetable.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 class Timetable: ObservableObject {
-    var lectures: [Lecture]
+    @Published var lectures: [Lecture]
     
     init(lectures: [Lecture]) {
         self.lectures = lectures

--- a/SNUTT-2022/SNUTT/Models/Timetable.swift
+++ b/SNUTT-2022/SNUTT/Models/Timetable.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 class Timetable: ObservableObject {
     @Published var lectures: [Lecture]
-    
+
     init(lectures: [Lecture]) {
         self.lectures = lectures
     }

--- a/SNUTT-2022/SNUTT/Models/Timetable.swift
+++ b/SNUTT-2022/SNUTT/Models/Timetable.swift
@@ -5,6 +5,12 @@
 //  Created by Jinsup Keum on 2022/03/19.
 //
 
-import Foundation
+import SwiftUI
 
-struct Timetable {}
+class Timetable: ObservableObject {
+    var lectures: [Lecture]
+    
+    init(lectures: [Lecture]) {
+        self.lectures = lectures
+    }
+}

--- a/SNUTT-2022/SNUTT/Models/TimetableSetting.swift
+++ b/SNUTT-2022/SNUTT/Models/TimetableSetting.swift
@@ -10,13 +10,13 @@ import SwiftUI
 class TimetableSetting: ObservableObject {
     let minHour: Int = 8
     let maxHour: Int = 19
-    
+
     let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
-    
+
     var hourCount: Int {
         maxHour - minHour + 1
     }
-    
+
     var weekCount: Int {
         visibleWeeks.count
     }

--- a/SNUTT-2022/SNUTT/Models/TimetableSetting.swift
+++ b/SNUTT-2022/SNUTT/Models/TimetableSetting.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class DrawingSetting: ObservableObject {
+class TimetableSetting: ObservableObject {
     let minHour: Int = 8
     let maxHour: Int = 19
     

--- a/SNUTT-2022/SNUTT/Models/User.swift
+++ b/SNUTT-2022/SNUTT/Models/User.swift
@@ -1,0 +1,14 @@
+//
+//  User.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/25.
+//
+
+import SwiftUI
+
+class User: ObservableObject {
+    var token: String?
+    var userId: String?
+    var registeredFCMToken: String?
+}

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -11,11 +11,11 @@ import SwiftUI
 class MyLectureListViewModel: ObservableObject {
     @ObservedObject private var state: AppState
     
-    var currentTimetable: AppState.CurrentTimetable {
+    var currentTimetable: Timetable {
         state.currentTimetable
     }
     
-    func updateTimetable(timeTable: AppState.CurrentTimetable) {
+    func updateTimetable(timeTable: Timetable) {
         state.currentTimetable = timeTable
     }
     

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -8,8 +8,8 @@
 import Foundation
 import SwiftUI
 
-class MyLectureListViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
+class MyLectureListViewModel {
+    private var state: AppState
     
     var currentTimetable: Timetable {
         state.currentTimetable

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  MyLectureListViewModel.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/24.
+//
+
+import Foundation
+import SwiftUI
+
+class MyLectureListViewModel: ObservableObject {
+    @ObservedObject private var state: AppState
+    
+    var currentTimetable: AppState.CurrentTimetable {
+        state.currentTimetable
+    }
+    
+    func updateTimetable(timeTable: AppState.CurrentTimetable) {
+        state.currentTimetable = timeTable
+    }
+    
+    init(appState: AppState) {
+        self.state = appState
+    }
+}

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -10,15 +10,15 @@ import SwiftUI
 
 class MyLectureListViewModel {
     var appState: AppState
-    
+
     var currentTimetable: Timetable {
         appState.currentTimetable
     }
-    
+
     func updateTimetable(timeTable: Timetable) {
         appState.currentTimetable = timeTable
     }
-    
+
     init(appState: AppState) {
         self.appState = appState
     }

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -9,17 +9,17 @@ import Foundation
 import SwiftUI
 
 class MyLectureListViewModel {
-    private var state: AppState
+    var appState: AppState
     
     var currentTimetable: Timetable {
-        state.currentTimetable
+        appState.currentTimetable
     }
     
     func updateTimetable(timeTable: Timetable) {
-        state.currentTimetable = timeTable
+        appState.currentTimetable = timeTable
     }
     
     init(appState: AppState) {
-        self.state = appState
+        self.appState = appState
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -11,11 +11,11 @@ import SwiftUI
 class ReviewViewModel: ObservableObject {
     @ObservedObject private var state: AppState
     
-    var currentTimetable: AppState.CurrentTimetable {
+    var currentTimetable: Timetable {
         state.currentTimetable
     }
 
-    func updateTimetable(timeTable: AppState.CurrentTimetable) {
+    func updateTimetable(timeTable: Timetable) {
         state.currentTimetable = timeTable
     }
     

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  ReviewViewModel.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/25.
+//
+
+import Foundation
+import SwiftUI
+
+class ReviewViewModel: ObservableObject {
+    @ObservedObject private var state: AppState
+    
+    var currentTimetable: AppState.CurrentTimetable {
+        state.currentTimetable
+    }
+
+    func updateTimetable(timeTable: AppState.CurrentTimetable) {
+        state.currentTimetable = timeTable
+    }
+    
+    init(appState: AppState) {
+        self.state = appState
+    }
+}

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -10,15 +10,15 @@ import SwiftUI
 
 class ReviewViewModel {
     var appState: AppState
-    
+
     var currentTimetable: Timetable {
         appState.currentTimetable
     }
 
-    func updateTimetable(timeTable: Timetable) {
+    func updateTimetable(timeTable _: Timetable) {
         appState.currentTimetable.lectures = []
     }
-    
+
     init(appState: AppState) {
         self.appState = appState
     }

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -8,15 +8,15 @@
 import Foundation
 import SwiftUI
 
-class ReviewViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
+class ReviewViewModel {
+    private var state: AppState
     
     var currentTimetable: Timetable {
         state.currentTimetable
     }
 
     func updateTimetable(timeTable: Timetable) {
-        state.currentTimetable = timeTable
+        state.currentTimetable.lectures = []
     }
     
     init(appState: AppState) {

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -9,17 +9,17 @@ import Foundation
 import SwiftUI
 
 class ReviewViewModel {
-    private var state: AppState
+    var appState: AppState
     
     var currentTimetable: Timetable {
-        state.currentTimetable
+        appState.currentTimetable
     }
 
     func updateTimetable(timeTable: Timetable) {
-        state.currentTimetable.lectures = []
+        appState.currentTimetable.lectures = []
     }
     
     init(appState: AppState) {
-        self.state = appState
+        self.appState = appState
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -8,8 +8,8 @@
 import Foundation
 import SwiftUI
 
-class SettingViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
+class SettingViewModel {
+     private var state: AppState
     
     var currentUser: User {
         state.currentUser

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -9,17 +9,17 @@ import Foundation
 import SwiftUI
 
 class SettingViewModel {
-     private var state: AppState
+    var appState: AppState
     
     var currentUser: User {
-        state.currentUser
+        appState.currentUser
     }
     
     func updateCurrentUser(user: User) {
-        state.currentUser = user
+        appState.currentUser = user
     }
     
     init(appState: AppState) {
-        self.state = appState
+        self.appState = appState
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -10,15 +10,15 @@ import SwiftUI
 
 class SettingViewModel {
     var appState: AppState
-    
+
     var currentUser: User {
         appState.currentUser
     }
-    
+
     func updateCurrentUser(user: User) {
         appState.currentUser = user
     }
-    
+
     init(appState: AppState) {
         self.appState = appState
     }

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  SettingViewModel.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/24.
+//
+
+import Foundation
+import SwiftUI
+
+class SettingViewModel: ObservableObject {
+    @ObservedObject private var state: AppState
+    
+    var currentUser: AppState.CurrentUser {
+        state.currentUser
+    }
+    
+    func updateCurrentUser(user: AppState.CurrentUser) {
+        state.currentUser = user
+    }
+    
+    init(appState: AppState) {
+        self.state = appState
+    }
+}

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -11,11 +11,11 @@ import SwiftUI
 class SettingViewModel: ObservableObject {
     @ObservedObject private var state: AppState
     
-    var currentUser: AppState.CurrentUser {
+    var currentUser: User {
         state.currentUser
     }
     
-    func updateCurrentUser(user: AppState.CurrentUser) {
+    func updateCurrentUser(user: User) {
         state.currentUser = user
     }
     

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -6,66 +6,73 @@
 //
 
 import UIKit
+import SwiftUI
 
-class TimetableViewModel {
-    /// 시간표 맨 왼쪽, 시간들을 나타내는 열의 너비
-    let hourWidth: CGFloat = 20
-
-    /// 시간표 맨 위쪽, 날짜를 나타내는 행의 높이
-    let weekdayHeight: CGFloat = 25
-
-    // To be deprecated by AppState.settings
-    let minHour: Int = 8
-    let maxHour: Int = 19
-
-    // To be deprecated by AppState.currentTimetable
-    let lectures = DummyAppState.shared.lectures
-    let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
-
-    var hourCount: Int {
-        maxHour - minHour + 1
+class TimetableViewModel: ObservableObject {
+    @ObservedObject private var state: AppState
+    
+    var drawing = TimetableDrawing()
+    
+    var currentTimetable: AppState.CurrentTimetable {
+        state.currentTimetable
     }
-
-    var weekCount: Int {
-        visibleWeeks.count
+    
+    var drawingSetting: AppState.DrawingSetting {
+        state.setting.drawing
     }
-
-    /// 컨테이너의 사이즈가 주어졌을 때, 하루의 너비를 계산한다.
-    func getWeekWidth(in containerSize: CGSize) -> CGFloat {
-        return (containerSize.width - hourWidth) / CGFloat(weekCount)
+    
+    func updateTimetable(timeTable: AppState.CurrentTimetable) {
+        state.currentTimetable = timeTable
     }
-
-    /// 컨테이너의 사이즈가 주어졌을 때, 한 시간의 높이를 계산한다.
-    func getHourHeight(in containerSize: CGSize) -> CGFloat {
-        return (containerSize.height - weekdayHeight) / CGFloat(hourCount)
+    
+    init(appState: AppState) {
+        self.state = appState
     }
-
-    /// 주어진 `TimePlace` 블록의 좌표(오프셋)를 구한다.
-    ///
-    /// 주어진 `TimePlace`를 시간표에 표시할 수 없는 경우(e.g. 시간이나 요일 범위에서 벗어난 경우 등)에는 `nil`을 리턴한다.
-    func getOffset(of timePlace: TimePlace, in containerSize: CGSize) -> CGPoint? {
-        if containerSize == .zero {
-            return nil
+    
+    struct TimetableDrawing {
+        /// 시간표 맨 왼쪽, 시간들을 나타내는 열의 너비
+        let hourWidth: CGFloat = 20
+        
+        /// 시간표 맨 위쪽, 날짜를 나타내는 행의 높이
+        let weekdayHeight: CGFloat = 25
+        
+        /// 컨테이너의 사이즈가 주어졌을 때, 하루의 너비를 계산한다.
+        func getWeekWidth(in containerSize: CGSize, weekCount: Int) -> CGFloat {
+            return (containerSize.width - hourWidth) / CGFloat(weekCount)
         }
-        let hourIndex = timePlace.startTime - Double(minHour)
-        guard let weekdayIndex = visibleWeeks.firstIndex(of: timePlace.day) else { return nil }
-        if hourIndex < 0 {
-            return nil
+        
+        /// 컨테이너의 사이즈가 주어졌을 때, 한 시간의 높이를 계산한다.
+        func getHourHeight(in containerSize: CGSize, hourCount: Int) -> CGFloat {
+            return (containerSize.height - weekdayHeight) / CGFloat(hourCount)
         }
-
-        let x = hourWidth + CGFloat(weekdayIndex) * getWeekWidth(in: containerSize)
-        let y = weekdayHeight + CGFloat(hourIndex) * getHourHeight(in: containerSize)
-
-        return CGPoint(x: x, y: y)
+        
+        /// 주어진 `TimePlace` 블록의 좌표(오프셋)를 구한다.
+        ///
+        /// 주어진 `TimePlace`를 시간표에 표시할 수 없는 경우(e.g. 시간이나 요일 범위에서 벗어난 경우 등)에는 `nil`을 리턴한다.
+        func getOffset(of timePlace: TimePlace, in containerSize: CGSize, drawingSetting: AppState.DrawingSetting) -> CGPoint? {
+            if containerSize == .zero {
+                return nil
+            }
+            let hourIndex = timePlace.startTime - Double(drawingSetting.minHour)
+            guard let weekdayIndex = drawingSetting.visibleWeeks.firstIndex(of: timePlace.day) else { return nil }
+            if hourIndex < 0 {
+                return nil
+            }
+            
+            let x = hourWidth + CGFloat(weekdayIndex) * getWeekWidth(in: containerSize, weekCount: drawingSetting.weekCount)
+            let y = weekdayHeight + CGFloat(hourIndex) * getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
+            
+            return CGPoint(x: x, y: y)
+        }
+        
+        /// 주어진 `TimePlace`블록의 높이를 구한다.
+        func getHeight(of timePlace: TimePlace, in containerSize: CGSize, hourCount: Int) -> CGFloat {
+            return timePlace.len * getHourHeight(in: containerSize, hourCount: hourCount)
+        }
+        
+        // for test(remove and implement otherwise)
+        //    func update() {
+        //        appState.system.showActivityIndicator = !appState.system.showActivityIndicator
+        //    }
     }
-
-    /// 주어진 `TimePlace`블록의 높이를 구한다.
-    func getHeight(of timePlace: TimePlace, in containerSize: CGSize) -> CGFloat {
-        return timePlace.len * getHourHeight(in: containerSize)
-    }
-
-    // for test(remove and implement otherwise)
-//    func update() {
-//        appState.system.showActivityIndicator = !appState.system.showActivityIndicator
-//    }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -5,47 +5,47 @@
 //  Created by Jinsup Keum on 2022/03/19.
 //
 
-import UIKit
 import SwiftUI
+import UIKit
 
 class TimetableViewModel {
     var appState: AppState
-    
+
     static let timetableDrawing = TimetableDrawing()
-    
+
     var currentTimetable: Timetable {
         appState.currentTimetable
     }
-    
+
     var drawingSetting: TimetableSetting {
         appState.setting.drawing
     }
-    
+
     func updateTimetable(timeTable: Timetable) {
         appState.currentTimetable = timeTable
     }
-    
+
     init(appState: AppState) {
         self.appState = appState
     }
-    
+
     struct TimetableDrawing {
         /// 시간표 맨 왼쪽, 시간들을 나타내는 열의 너비
         let hourWidth: CGFloat = 20
-        
+
         /// 시간표 맨 위쪽, 날짜를 나타내는 행의 높이
         let weekdayHeight: CGFloat = 25
-        
+
         /// 컨테이너의 사이즈가 주어졌을 때, 하루의 너비를 계산한다.
         func getWeekWidth(in containerSize: CGSize, weekCount: Int) -> CGFloat {
             return (containerSize.width - hourWidth) / CGFloat(weekCount)
         }
-        
+
         /// 컨테이너의 사이즈가 주어졌을 때, 한 시간의 높이를 계산한다.
         func getHourHeight(in containerSize: CGSize, hourCount: Int) -> CGFloat {
             return (containerSize.height - weekdayHeight) / CGFloat(hourCount)
         }
-        
+
         /// 주어진 `TimePlace` 블록의 좌표(오프셋)를 구한다.
         ///
         /// 주어진 `TimePlace`를 시간표에 표시할 수 없는 경우(e.g. 시간이나 요일 범위에서 벗어난 경우 등)에는 `nil`을 리턴한다.
@@ -58,18 +58,18 @@ class TimetableViewModel {
             if hourIndex < 0 {
                 return nil
             }
-            
+
             let x = hourWidth + CGFloat(weekdayIndex) * getWeekWidth(in: containerSize, weekCount: drawingSetting.weekCount)
             let y = weekdayHeight + CGFloat(hourIndex) * getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
-            
+
             return CGPoint(x: x, y: y)
         }
-        
+
         /// 주어진 `TimePlace`블록의 높이를 구한다.
         func getHeight(of timePlace: TimePlace, in containerSize: CGSize, hourCount: Int) -> CGFloat {
             return timePlace.len * getHourHeight(in: containerSize, hourCount: hourCount)
         }
-        
+
         // for test(remove and implement otherwise)
         //    func update() {
         //        appState.system.showActivityIndicator = !appState.system.showActivityIndicator

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -8,8 +8,8 @@
 import UIKit
 import SwiftUI
 
-class TimetableViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
+class TimetableViewModel {
+    private var state: AppState
     
     var drawing = TimetableDrawing()
     

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -17,7 +17,7 @@ class TimetableViewModel: ObservableObject {
         state.currentTimetable
     }
     
-    var drawingSetting: DrawingSetting {
+    var drawingSetting: TimetableSetting {
         state.setting.drawing
     }
     
@@ -49,7 +49,7 @@ class TimetableViewModel: ObservableObject {
         /// 주어진 `TimePlace` 블록의 좌표(오프셋)를 구한다.
         ///
         /// 주어진 `TimePlace`를 시간표에 표시할 수 없는 경우(e.g. 시간이나 요일 범위에서 벗어난 경우 등)에는 `nil`을 리턴한다.
-        func getOffset(of timePlace: TimePlace, in containerSize: CGSize, drawingSetting: DrawingSetting) -> CGPoint? {
+        func getOffset(of timePlace: TimePlace, in containerSize: CGSize, drawingSetting: TimetableSetting) -> CGPoint? {
             if containerSize == .zero {
                 return nil
             }

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -9,24 +9,24 @@ import UIKit
 import SwiftUI
 
 class TimetableViewModel {
-    private var state: AppState
+    var appState: AppState
     
     var drawing = TimetableDrawing()
     
     var currentTimetable: Timetable {
-        state.currentTimetable
+        appState.currentTimetable
     }
     
     var drawingSetting: TimetableSetting {
-        state.setting.drawing
+        appState.setting.drawing
     }
     
     func updateTimetable(timeTable: Timetable) {
-        state.currentTimetable = timeTable
+        appState.currentTimetable = timeTable
     }
     
     init(appState: AppState) {
-        self.state = appState
+        self.appState = appState
     }
     
     struct TimetableDrawing {

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 class TimetableViewModel {
     var appState: AppState
     
-    var drawing = TimetableDrawing()
+    static let timetableDrawing = TimetableDrawing()
     
     var currentTimetable: Timetable {
         appState.currentTimetable

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -13,15 +13,15 @@ class TimetableViewModel: ObservableObject {
     
     var drawing = TimetableDrawing()
     
-    var currentTimetable: AppState.CurrentTimetable {
+    var currentTimetable: Timetable {
         state.currentTimetable
     }
     
-    var drawingSetting: AppState.DrawingSetting {
+    var drawingSetting: DrawingSetting {
         state.setting.drawing
     }
     
-    func updateTimetable(timeTable: AppState.CurrentTimetable) {
+    func updateTimetable(timeTable: Timetable) {
         state.currentTimetable = timeTable
     }
     
@@ -49,7 +49,7 @@ class TimetableViewModel: ObservableObject {
         /// 주어진 `TimePlace` 블록의 좌표(오프셋)를 구한다.
         ///
         /// 주어진 `TimePlace`를 시간표에 표시할 수 없는 경우(e.g. 시간이나 요일 범위에서 벗어난 경우 등)에는 `nil`을 리턴한다.
-        func getOffset(of timePlace: TimePlace, in containerSize: CGSize, drawingSetting: AppState.DrawingSetting) -> CGPoint? {
+        func getOffset(of timePlace: TimePlace, in containerSize: CGSize, drawingSetting: DrawingSetting) -> CGPoint? {
             if containerSize == .zero {
                 return nil
             }

--- a/SNUTT-2022/SNUTT/Views/Components/LectureDetails.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureDetails.swift
@@ -15,8 +15,8 @@ struct LectureDetails: View {
     }
 }
 
-// struct LectureDetailList_Previews: PreviewProvider {
-//    static var previews: some View {
-//        LectureDetails()
-//    }
-// }
+ struct LectureDetailList_Previews: PreviewProvider {
+    static var previews: some View {
+        LectureDetails()
+    }
+ }

--- a/SNUTT-2022/SNUTT/Views/Components/LectureDetails.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureDetails.swift
@@ -15,8 +15,8 @@ struct LectureDetails: View {
     }
 }
 
- struct LectureDetailList_Previews: PreviewProvider {
+struct LectureDetailList_Previews: PreviewProvider {
     static var previews: some View {
         LectureDetails()
     }
- }
+}

--- a/SNUTT-2022/SNUTT/Views/Components/LectureList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureList.swift
@@ -24,13 +24,17 @@ struct LectureList: View {
                 LectureListCell(lecture: lecture)
             }
         }.listStyle(PlainListStyle())
+        
+        let _ = debugChanges()
     }
 }
 
 struct TimetableList_Previews: PreviewProvider {
     static var previews: some View {
+        let appState = AppState()
+        
         NavigationView {
-            LectureList(lectures: DummyAppState.shared.lectures)
+            LectureList(lectures: appState.currentTimetable.lectures)
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/LectureList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureList.swift
@@ -24,7 +24,7 @@ struct LectureList: View {
                 LectureListCell(lecture: lecture)
             }
         }.listStyle(PlainListStyle())
-        
+
         let _ = debugChanges()
     }
 }
@@ -32,7 +32,7 @@ struct LectureList: View {
 struct TimetableList_Previews: PreviewProvider {
     static var previews: some View {
         let appState = AppState()
-        
+
         NavigationView {
             LectureList(lectures: appState.currentTimetable.lectures)
         }

--- a/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct LectureListCell: View {
     let lecture: Lecture
-    
+
     @ViewBuilder
     func detailRow(imageName: String, text: String) -> some View {
         HStack {
@@ -19,7 +19,7 @@ struct LectureListCell: View {
             Spacer()
         }
     }
-    
+
     var body: some View {
         VStack(spacing: 8) {
             // title
@@ -30,14 +30,14 @@ struct LectureListCell: View {
                 Text("정희숙 / 3학점")
                     .font(STFont.details)
             }
-            
+
             // details
             detailRow(imageName: "tag.black", text: "디자인학부(디자인전공), 3학년")
             detailRow(imageName: "clock.black", text: "목2")
             detailRow(imageName: "map.black", text: "049-215")
         }
         .padding(.vertical, 5)
-        
+
         let _ = debugChanges()
     }
 }
@@ -49,7 +49,7 @@ struct TimetableListCell_Previews: PreviewProvider {
             TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
             TimePlace(day: Weekday(rawValue: 3)!, start: 4.70, len: 1.5, place: "302-123"),
         ])
-        
+
         LectureListCell(lecture: lecture)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
@@ -24,7 +24,7 @@ struct LectureListCell: View {
         VStack(spacing: 8) {
             // title
             HStack {
-                Text("편집디자인")
+                Text(lecture.title)
                     .font(STFont.subheading)
                 Spacer()
                 Text("정희숙 / 3학점")

--- a/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct LectureListCell: View {
     let lecture: Lecture
-
+    
     @ViewBuilder
     func detailRow(imageName: String, text: String) -> some View {
         HStack {
@@ -19,7 +19,7 @@ struct LectureListCell: View {
             Spacer()
         }
     }
-
+    
     var body: some View {
         VStack(spacing: 8) {
             // title
@@ -30,18 +30,26 @@ struct LectureListCell: View {
                 Text("정희숙 / 3학점")
                     .font(STFont.details)
             }
-
+            
             // details
             detailRow(imageName: "tag.black", text: "디자인학부(디자인전공), 3학년")
             detailRow(imageName: "clock.black", text: "목2")
             detailRow(imageName: "map.black", text: "049-215")
         }
         .padding(.vertical, 5)
+        
+        let _ = debugChanges()
     }
 }
 
 struct TimetableListCell_Previews: PreviewProvider {
     static var previews: some View {
-        LectureListCell(lecture: DummyAppState.shared.dummyLecture)
+        let lecture = Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
+            TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
+            TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
+            TimePlace(day: Weekday(rawValue: 3)!, start: 4.70, len: 1.5, place: "302-123"),
+        ])
+        
+        LectureListCell(lecture: lecture)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlock.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlock.swift
@@ -31,7 +31,7 @@ struct TimetableBlock: View {
 
 struct TimetableBlock_Previews: PreviewProvider {
     static var previews: some View {
-        let lecture = DummyAppState.shared.lectures.first!
+        let lecture = AppState().currentTimetable.lectures.first!
         TimetableBlock(lecture: lecture, timePlace: lecture.timePlaces[0])
             .frame(width: 70, height: 100, alignment: .center)
     }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TimetableBlocksLayer: View {
-    let drawing: TimetableViewModel.TimetableDrawing
     @EnvironmentObject var drawingSetting: TimetableSetting
     @EnvironmentObject var currentTimetable: Timetable
     
@@ -16,9 +15,9 @@ struct TimetableBlocksLayer: View {
         GeometryReader { reader in
             ForEach(currentTimetable.lectures) { lecture in
                 ForEach(lecture.timePlaces) { timePlace in
-                    if let offsetPoint = drawing.getOffset(of: timePlace, in: reader.size, drawingSetting: drawingSetting) {
+                    if let offsetPoint = TimetableViewModel.timetableDrawing.getOffset(of: timePlace, in: reader.size, drawingSetting: drawingSetting) {
                         TimetableBlock(lecture: lecture, timePlace: timePlace)
-                            .frame(width: drawing.getWeekWidth(in: reader.size, weekCount: drawingSetting.weekCount), height: drawing.getHeight(of: timePlace, in: reader.size, hourCount: drawingSetting.hourCount), alignment: .center)
+                            .frame(width: TimetableViewModel.timetableDrawing.getWeekWidth(in: reader.size, weekCount: drawingSetting.weekCount), height: TimetableViewModel.timetableDrawing.getHeight(of: timePlace, in: reader.size, hourCount: drawingSetting.hourCount), alignment: .center)
                             .offset(x: offsetPoint.x, y: offsetPoint.y)
                     }
                 }
@@ -33,10 +32,10 @@ struct TimetableBlocks_Previews: PreviewProvider {
     static var previews: some View {
         ZStack {
             let viewModel = TimetableViewModel(appState: AppState())
-            TimetableBlocksLayer(drawing: viewModel.drawing)
+            TimetableBlocksLayer()
                 .environmentObject(viewModel.currentTimetable)
                 .environmentObject(viewModel.drawingSetting)
-            TimetableGridLayer(drawing: viewModel.drawing)
+            TimetableGridLayer()
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct TimetableBlocksLayer: View {
     let drawing: TimetableViewModel.TimetableDrawing
-    @EnvironmentObject var drawingSetting: AppState.DrawingSetting
-    @EnvironmentObject var currentTimetable: AppState.CurrentTimetable
+    @EnvironmentObject var drawingSetting: DrawingSetting
+    @EnvironmentObject var currentTimetable: Timetable
     
     var body: some View {
         GeometryReader { reader in

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -28,13 +28,15 @@ struct TimetableBlocksLayer: View {
         let _ = debugChanges()
     }
 }
-//
-//struct TimetableBlocks_Previews: PreviewProvider {
-//    static var previews: some View {
-//        ZStack {
-//            let viewModel = TimetableViewModel()
-//            TimetableBlocksLayer(viewModel: viewModel)
-//            TimetableGridLayer(viewModel: viewModel)
-//        }
-//    }
-//}
+
+struct TimetableBlocks_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            let viewModel = TimetableViewModel(appState: AppState())
+            TimetableBlocksLayer(drawing: viewModel.drawing)
+                .environmentObject(viewModel.currentTimetable)
+                .environmentObject(viewModel.drawingSetting)
+            TimetableGridLayer(drawing: viewModel.drawing)
+        }
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct TimetableBlocksLayer: View {
     @EnvironmentObject var drawingSetting: TimetableSetting
     @EnvironmentObject var currentTimetable: Timetable
-    
+
     var body: some View {
         GeometryReader { reader in
             ForEach(currentTimetable.lectures) { lecture in
@@ -23,7 +23,7 @@ struct TimetableBlocksLayer: View {
                 }
             }
         }
-        
+
         let _ = debugChanges()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -8,29 +8,33 @@
 import SwiftUI
 
 struct TimetableBlocksLayer: View {
-    let viewModel: TimetableViewModel
-
+    let drawing: TimetableViewModel.TimetableDrawing
+    @EnvironmentObject var drawingSetting: AppState.DrawingSetting
+    @EnvironmentObject var currentTimetable: AppState.CurrentTimetable
+    
     var body: some View {
         GeometryReader { reader in
-            ForEach(viewModel.lectures) { lecture in
+            ForEach(currentTimetable.lectures) { lecture in
                 ForEach(lecture.timePlaces) { timePlace in
-                    if let offsetPoint = viewModel.getOffset(of: timePlace, in: reader.size) {
+                    if let offsetPoint = drawing.getOffset(of: timePlace, in: reader.size, drawingSetting: drawingSetting) {
                         TimetableBlock(lecture: lecture, timePlace: timePlace)
-                            .frame(width: viewModel.getWeekWidth(in: reader.size), height: viewModel.getHeight(of: timePlace, in: reader.size), alignment: .center)
+                            .frame(width: drawing.getWeekWidth(in: reader.size, weekCount: drawingSetting.weekCount), height: drawing.getHeight(of: timePlace, in: reader.size, hourCount: drawingSetting.hourCount), alignment: .center)
                             .offset(x: offsetPoint.x, y: offsetPoint.y)
                     }
                 }
             }
         }
+        
+        let _ = debugChanges()
     }
 }
-
-struct TimetableBlocks_Previews: PreviewProvider {
-    static var previews: some View {
-        ZStack {
-            let viewModel = TimetableViewModel()
-            TimetableBlocksLayer(viewModel: viewModel)
-            TimetableGridLayer(viewModel: viewModel)
-        }
-    }
-}
+//
+//struct TimetableBlocks_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ZStack {
+//            let viewModel = TimetableViewModel()
+//            TimetableBlocksLayer(viewModel: viewModel)
+//            TimetableGridLayer(viewModel: viewModel)
+//        }
+//    }
+//}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TimetableBlocksLayer: View {
     let drawing: TimetableViewModel.TimetableDrawing
-    @EnvironmentObject var drawingSetting: DrawingSetting
+    @EnvironmentObject var drawingSetting: TimetableSetting
     @EnvironmentObject var currentTimetable: Timetable
     
     var body: some View {

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -21,7 +21,7 @@ struct TimetableGridLayer: View {
             horizontalHalfHourlyPaths(in: reader.size)
                 .stroke(Color(UIColor.quaternaryLabel.withAlphaComponent(0.05)))
         }
-        
+
         let _ = debugChanges()
     }
 

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TimetableGridLayer: View {
-    let drawing: TimetableViewModel.TimetableDrawing
     @EnvironmentObject var drawingSetting: TimetableSetting
 
     var body: some View {
@@ -30,10 +29,10 @@ struct TimetableGridLayer: View {
 
     /// 하루 간격의 수직선
     func verticalPaths(in containerSize: CGSize) -> Path {
-        let weekWidth = drawing.getWeekWidth(in: containerSize, weekCount: drawingSetting.weekCount)
+        let weekWidth = TimetableViewModel.timetableDrawing.getWeekWidth(in: containerSize, weekCount: drawingSetting.weekCount)
         return Path { path in
             for i in 0 ..< drawingSetting.weekCount {
-                let x = drawing.hourWidth + CGFloat(i) * weekWidth
+                let x = TimetableViewModel.timetableDrawing.hourWidth + CGFloat(i) * weekWidth
                 path.move(to: CGPoint(x: x, y: 0))
                 path.addLine(to: CGPoint(x: x, y: containerSize.height))
             }
@@ -42,10 +41,10 @@ struct TimetableGridLayer: View {
 
     /// 한 시간 간격의 수평선
     func horizontalHourlyPaths(in containerSize: CGSize) -> Path {
-        let hourHeight = drawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
+        let hourHeight = TimetableViewModel.timetableDrawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
         return Path { path in
             for i in 0 ..< drawingSetting.hourCount {
-                let y = drawing.weekdayHeight + CGFloat(i) * hourHeight
+                let y = TimetableViewModel.timetableDrawing.weekdayHeight + CGFloat(i) * hourHeight
                 path.move(to: CGPoint(x: 0, y: y))
                 path.addLine(to: CGPoint(x: containerSize.width, y: y))
             }
@@ -54,11 +53,11 @@ struct TimetableGridLayer: View {
 
     /// 30분 간격의 수평선
     func horizontalHalfHourlyPaths(in containerSize: CGSize) -> Path {
-        let hourHeight = drawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
+        let hourHeight = TimetableViewModel.timetableDrawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
         return Path { path in
             for i in 0 ..< drawingSetting.hourCount {
-                let y = drawing.weekdayHeight + CGFloat(i) * hourHeight + hourHeight / 2
-                path.move(to: CGPoint(x: 0 + drawing.hourWidth, y: y))
+                let y = TimetableViewModel.timetableDrawing.weekdayHeight + CGFloat(i) * hourHeight + hourHeight / 2
+                path.move(to: CGPoint(x: 0 + TimetableViewModel.timetableDrawing.hourWidth, y: y))
                 path.addLine(to: CGPoint(x: containerSize.width, y: y))
             }
         }
@@ -74,10 +73,10 @@ struct TimetableGridLayer: View {
                     .font(STFont.details)
                     .foregroundColor(Color(UIColor.secondaryLabel))
                     .frame(maxWidth: .infinity)
-                    .frame(height: drawing.weekdayHeight)
+                    .frame(height: TimetableViewModel.timetableDrawing.weekdayHeight)
             }
         }
-        .padding(.leading, drawing.hourWidth)
+        .padding(.leading, TimetableViewModel.timetableDrawing.hourWidth)
     }
 
     /// 시간표 맨 왼쪽, 시간들을 나타내는 행
@@ -88,18 +87,18 @@ struct TimetableGridLayer: View {
                     .font(STFont.details)
                     .foregroundColor(Color(UIColor.secondaryLabel))
                     .padding(.top, 5)
-                    .frame(width: drawing.hourWidth)
+                    .frame(width: TimetableViewModel.timetableDrawing.hourWidth)
                     .frame(maxHeight: .infinity, alignment: .top)
             }
         }
-        .padding(.top, drawing.weekdayHeight)
+        .padding(.top, TimetableViewModel.timetableDrawing.weekdayHeight)
     }
 }
 
 struct TimetableGrid_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = TimetableViewModel(appState: AppState())
-        TimetableGridLayer(drawing: viewModel.drawing)
+        TimetableGridLayer()
             .environmentObject(viewModel.drawingSetting)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TimetableGridLayer: View {
     let drawing: TimetableViewModel.TimetableDrawing
-    @EnvironmentObject var drawingSetting: AppState.DrawingSetting
+    @EnvironmentObject var drawingSetting: DrawingSetting
 
     var body: some View {
         GeometryReader { reader in

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -95,9 +95,11 @@ struct TimetableGridLayer: View {
         .padding(.top, drawing.weekdayHeight)
     }
 }
-//
-//struct TimetableGrid_Previews: PreviewProvider {
-//    static var previews: some View {
-//        TimetableGridLayer(viewModel: TimetableViewModel())
-//    }
-//}
+
+struct TimetableGrid_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = TimetableViewModel(appState: AppState())
+        TimetableGridLayer(drawing: viewModel.drawing)
+            .environmentObject(viewModel.drawingSetting)
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct TimetableGridLayer: View {
-    let viewModel: TimetableViewModel
+    let drawing: TimetableViewModel.TimetableDrawing
+    @EnvironmentObject var drawingSetting: AppState.DrawingSetting
 
     var body: some View {
         GeometryReader { reader in
@@ -21,16 +22,18 @@ struct TimetableGridLayer: View {
             horizontalHalfHourlyPaths(in: reader.size)
                 .stroke(Color(UIColor.quaternaryLabel.withAlphaComponent(0.05)))
         }
+        
+        let _ = debugChanges()
     }
 
     // MARK: Grid Paths
 
     /// 하루 간격의 수직선
     func verticalPaths(in containerSize: CGSize) -> Path {
-        let weekWidth = viewModel.getWeekWidth(in: containerSize)
+        let weekWidth = drawing.getWeekWidth(in: containerSize, weekCount: drawingSetting.weekCount)
         return Path { path in
-            for i in 0 ..< viewModel.weekCount {
-                let x = viewModel.hourWidth + CGFloat(i) * weekWidth
+            for i in 0 ..< drawingSetting.weekCount {
+                let x = drawing.hourWidth + CGFloat(i) * weekWidth
                 path.move(to: CGPoint(x: x, y: 0))
                 path.addLine(to: CGPoint(x: x, y: containerSize.height))
             }
@@ -39,10 +42,10 @@ struct TimetableGridLayer: View {
 
     /// 한 시간 간격의 수평선
     func horizontalHourlyPaths(in containerSize: CGSize) -> Path {
-        let hourHeight = viewModel.getHourHeight(in: containerSize)
+        let hourHeight = drawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
         return Path { path in
-            for i in 0 ..< viewModel.hourCount {
-                let y = viewModel.weekdayHeight + CGFloat(i) * hourHeight
+            for i in 0 ..< drawingSetting.hourCount {
+                let y = drawing.weekdayHeight + CGFloat(i) * hourHeight
                 path.move(to: CGPoint(x: 0, y: y))
                 path.addLine(to: CGPoint(x: containerSize.width, y: y))
             }
@@ -51,11 +54,11 @@ struct TimetableGridLayer: View {
 
     /// 30분 간격의 수평선
     func horizontalHalfHourlyPaths(in containerSize: CGSize) -> Path {
-        let hourHeight = viewModel.getHourHeight(in: containerSize)
+        let hourHeight = drawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
         return Path { path in
-            for i in 0 ..< viewModel.hourCount {
-                let y = viewModel.weekdayHeight + CGFloat(i) * hourHeight + hourHeight / 2
-                path.move(to: CGPoint(x: 0 + viewModel.hourWidth, y: y))
+            for i in 0 ..< drawingSetting.hourCount {
+                let y = drawing.weekdayHeight + CGFloat(i) * hourHeight + hourHeight / 2
+                path.move(to: CGPoint(x: 0 + drawing.hourWidth, y: y))
                 path.addLine(to: CGPoint(x: containerSize.width, y: y))
             }
         }
@@ -66,35 +69,35 @@ struct TimetableGridLayer: View {
     /// 시간표 맨 위쪽, 날짜를 나타내는 행
     var weeksHStack: some View {
         HStack(spacing: 0) {
-            ForEach(viewModel.visibleWeeks) { week in
+            ForEach(drawingSetting.visibleWeeks) { week in
                 Text(week.shortSymbol)
                     .font(STFont.details)
                     .foregroundColor(Color(UIColor.secondaryLabel))
                     .frame(maxWidth: .infinity)
-                    .frame(height: viewModel.weekdayHeight)
+                    .frame(height: drawing.weekdayHeight)
             }
         }
-        .padding(.leading, viewModel.hourWidth)
+        .padding(.leading, drawing.hourWidth)
     }
 
     /// 시간표 맨 왼쪽, 시간들을 나타내는 행
     var hoursVStack: some View {
         VStack(spacing: 0) {
-            ForEach(viewModel.minHour ... viewModel.maxHour, id: \.self) { hour in
+            ForEach(drawingSetting.minHour ... drawingSetting.maxHour, id: \.self) { hour in
                 Text(String(hour))
                     .font(STFont.details)
                     .foregroundColor(Color(UIColor.secondaryLabel))
                     .padding(.top, 5)
-                    .frame(width: viewModel.hourWidth)
+                    .frame(width: drawing.hourWidth)
                     .frame(maxHeight: .infinity, alignment: .top)
             }
         }
-        .padding(.top, viewModel.weekdayHeight)
+        .padding(.top, drawing.weekdayHeight)
     }
 }
-
-struct TimetableGrid_Previews: PreviewProvider {
-    static var previews: some View {
-        TimetableGridLayer(viewModel: TimetableViewModel())
-    }
-}
+//
+//struct TimetableGrid_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TimetableGridLayer(viewModel: TimetableViewModel())
+//    }
+//}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TimetableGridLayer: View {
     let drawing: TimetableViewModel.TimetableDrawing
-    @EnvironmentObject var drawingSetting: DrawingSetting
+    @EnvironmentObject var drawingSetting: TimetableSetting
 
     var body: some View {
         GeometryReader { reader in

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
@@ -8,20 +8,18 @@
 import SwiftUI
 
 struct TimetableZStack: View {
-    let drawing: TimetableViewModel.TimetableDrawing
-    
     var body: some View {
         ZStack {
-            TimetableGridLayer(drawing: drawing)
-            TimetableBlocksLayer(drawing: drawing)
+            TimetableGridLayer()
+            TimetableBlocksLayer()
         }
         
         let _ = debugChanges()
     }
 }
 //
-//struct TimetableStack_Previews: PreviewProvider {
-//    static var previews: some View {
-////        TimetableZStack(viewModel: TimetableViewModel())
-//    }
-//}
+struct TimetableStack_Previews: PreviewProvider {
+    static var previews: some View {
+        TimetableZStack()
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
@@ -8,17 +8,20 @@
 import SwiftUI
 
 struct TimetableZStack: View {
-    let viewModel: TimetableViewModel
+    let drawing: TimetableViewModel.TimetableDrawing
+    
     var body: some View {
         ZStack {
-            TimetableGridLayer(viewModel: viewModel)
-            TimetableBlocksLayer(viewModel: viewModel)
+            TimetableGridLayer(drawing: drawing)
+            TimetableBlocksLayer(drawing: drawing)
         }
+        
+        let _ = debugChanges()
     }
 }
-
-struct TimetableStack_Previews: PreviewProvider {
-    static var previews: some View {
-        TimetableZStack(viewModel: TimetableViewModel())
-    }
-}
+//
+//struct TimetableStack_Previews: PreviewProvider {
+//    static var previews: some View {
+////        TimetableZStack(viewModel: TimetableViewModel())
+//    }
+//}

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
@@ -13,10 +13,11 @@ struct TimetableZStack: View {
             TimetableGridLayer()
             TimetableBlocksLayer()
         }
-        
+
         let _ = debugChanges()
     }
 }
+
 //
 struct TimetableStack_Previews: PreviewProvider {
     static var previews: some View {

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -11,15 +11,13 @@ import SwiftUI
 struct SNUTTApp: App {
     @StateObject var appState = AppState()
 
-    let tabItems: [TabItem] = [
-        TabItem(id: .timetable, view: AnyView(MyTimetableScene()), symbolName: .timetable),
-        TabItem(id: .search, view: AnyView(MyLectureListScene()), symbolName: .search),
-        TabItem(id: .review, view: AnyView(MyLectureListScene()), symbolName: .review),
-        TabItem(id: .settings, view: AnyView(MyLectureListScene()), symbolName: .settings),
-    ]
-
     var body: some Scene {
-        let _ = AppStateContainer.shared.setAppState(appState: appState)
+        let tabItems: [TabItem] = [
+            TabItem(id: .timetable, view: AnyView(MyTimetableScene(viewModel: TimetableViewModel(appState: appState))), symbolName: .timetable),
+            TabItem(id: .search, view: AnyView(MyLectureListScene()), symbolName: .search),
+            TabItem(id: .review, view: AnyView(ReviewScene(viewModel: ReviewViewModel(appState: appState))), symbolName: .review),
+            TabItem(id: .settings, view: AnyView(SettingScene(viewModel: SettingViewModel(appState: appState))), symbolName: .settings),
+        ]
 
         WindowGroup {
             // 임시 Entry Point
@@ -81,5 +79,13 @@ struct TabItem: Identifiable {
 
     var offImageName: String {
         "tab.\(symbolName.rawValue).off"
+    }
+}
+
+extension View {
+    func debugChanges() {
+        if #available(iOS 15.0, *) {
+            let _ = Self._printChanges()
+        }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @main
 struct SNUTTApp: App {
-    var appState = AppState()
+    let appState = AppState()
     @State var selectedTab: SelectedTab = .timetable
     
     enum SelectedTab {

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SNUTTApp: App {
     let appState = AppState()
     @State var selectedTab: SelectedTab = .timetable
-    
+
     enum SelectedTab {
         case timetable
         case search
@@ -66,7 +66,7 @@ struct SNUTTApp: App {
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
     }
-    
+
     /// A simple wrapper struct that represents a tab view item.
     struct TabItem: Identifiable {
         enum SymbolName: String {
@@ -93,7 +93,7 @@ struct SNUTTApp: App {
 extension View {
     func debugChanges() {
         if #available(iOS 15.0, *) {
-            let _ = Self._printChanges()
+            _ = Self._printChanges()
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @main
 struct SNUTTApp: App {
-    @StateObject var appState = AppState()
+    var appState = AppState()
     @State var selectedTab: SelectedTab = .timetable
     
     enum SelectedTab {

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -22,7 +22,7 @@ struct SNUTTApp: App {
     var body: some Scene {
         let tabItems: [TabItem] = [
             TabItem(id: .timetable, view: AnyView(MyTimetableScene(viewModel: TimetableViewModel(appState: appState))), symbolName: .timetable),
-            TabItem(id: .search, view: AnyView(MyLectureListScene()), symbolName: .search),
+            TabItem(id: .search, view: AnyView(MyLectureListScene(viewModel: MyLectureListViewModel(appState: appState))), symbolName: .search),
             TabItem(id: .review, view: AnyView(ReviewScene(viewModel: ReviewViewModel(appState: appState))), symbolName: .review),
             TabItem(id: .settings, view: AnyView(SettingScene(viewModel: SettingViewModel(appState: appState))), symbolName: .settings),
         ]

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -10,6 +10,14 @@ import SwiftUI
 @main
 struct SNUTTApp: App {
     @StateObject var appState = AppState()
+    @State var selectedTab: SelectedTab = .timetable
+    
+    enum SelectedTab {
+        case timetable
+        case search
+        case review
+        case settings
+    }
 
     var body: some Scene {
         let tabItems: [TabItem] = [
@@ -21,14 +29,14 @@ struct SNUTTApp: App {
 
         WindowGroup {
             // 임시 Entry Point
-            TabView(selection: $appState.selectedTab) {
+            TabView(selection: $selectedTab) {
                 ForEach(tabItems) { tab in
                     NavigationView {
                         tab.view
                     }
                     .accentColor(Color(UIColor.label))
                     .tabItem {
-                        Image(appState.selectedTab == tab.id ? tab.onImageName : tab.offImageName)
+                        Image(selectedTab == tab.id ? tab.onImageName : tab.offImageName)
                     }
                 }
             }
@@ -58,27 +66,27 @@ struct SNUTTApp: App {
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
     }
-}
+    
+    /// A simple wrapper struct that represents a tab view item.
+    struct TabItem: Identifiable {
+        enum SymbolName: String {
+            case timetable
+            case search
+            case review
+            case settings
+        }
 
-/// A simple wrapper struct that represents a tab view item.
-struct TabItem: Identifiable {
-    enum SymbolName: String {
-        case timetable
-        case search
-        case review
-        case settings
-    }
+        let id: SelectedTab
+        let view: AnyView
+        let symbolName: SymbolName
 
-    let id: AppState.SelectedTab
-    let view: AnyView
-    let symbolName: SymbolName
+        var onImageName: String {
+            "tab.\(symbolName.rawValue).on"
+        }
 
-    var onImageName: String {
-        "tab.\(symbolName.rawValue).on"
-    }
-
-    var offImageName: String {
-        "tab.\(symbolName.rawValue).off"
+        var offImageName: String {
+            "tab.\(symbolName.rawValue).off"
+        }
     }
 }
 

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MyLectureListScene: View {
+    let viewModel: MyLectureListViewModel
+    
     let myDummyLectureList = [
         Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
             TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
@@ -39,7 +41,7 @@ struct MyTimetableListScene_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             TabView {
-                MyLectureListScene()
+                MyLectureListScene(viewModel: MyLectureListViewModel(appState: AppState()))
             }
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
@@ -8,8 +8,18 @@
 import SwiftUI
 
 struct MyLectureListScene: View {
-    let myDummyLectureList = DummyAppState.shared.lectures
-
+    let myDummyLectureList = [
+        Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
+            TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
+            TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
+            TimePlace(day: Weekday(rawValue: 3)!, start: 4.70, len: 1.5, place: "302-123"),
+        ]),
+        Lecture(id: 2, title: "컴퓨터구조", instructor: "김진수", timePlaces: [
+            TimePlace(day: Weekday(rawValue: 2)!, start: 7.5, len: 1.5, place: "302-123"),
+            TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
+        ]),
+    ]
+    
     var body: some View {
         LectureList(lectures: myDummyLectureList)
             .navigationBarTitleDisplayMode(.inline)
@@ -20,6 +30,8 @@ struct MyLectureListScene: View {
                     }
                 }
             }
+        
+        let _ = debugChanges()
     }
 }
 

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyLectureListScene: View {
     let viewModel: MyLectureListViewModel
-    
+
     var body: some View {
         LectureList(lectures: viewModel.currentTimetable.lectures)
             .navigationBarTitleDisplayMode(.inline)
@@ -20,7 +20,7 @@ struct MyLectureListScene: View {
                     }
                 }
             }
-        
+
         let _ = debugChanges()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
@@ -10,20 +10,8 @@ import SwiftUI
 struct MyLectureListScene: View {
     let viewModel: MyLectureListViewModel
     
-    let myDummyLectureList = [
-        Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
-            TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 3)!, start: 4.70, len: 1.5, place: "302-123"),
-        ]),
-        Lecture(id: 2, title: "컴퓨터구조", instructor: "김진수", timePlaces: [
-            TimePlace(day: Weekday(rawValue: 2)!, start: 7.5, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
-        ]),
-    ]
-    
     var body: some View {
-        LectureList(lectures: myDummyLectureList)
+        LectureList(lectures: viewModel.currentTimetable.lectures)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -12,7 +12,7 @@ struct MyTimetableScene: View {
     let viewModel: TimetableViewModel
     
     var body: some View {
-        TimetableZStack(drawing: viewModel.drawing)
+        TimetableZStack()
             .environmentObject(viewModel.currentTimetable)
             .environmentObject(viewModel.drawingSetting)
         // navigate programmatically, because NavigationLink inside toolbar doesn't work

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -55,12 +55,10 @@ struct MyTimetableScene: View {
     }
 }
 
-//struct MyTimetableScene_Previews: PreviewProvider {
-//    static var previews: some View {
-//        NavigationView {
-//            MyTimetableScene(currentTimetable: TimetableViewModel(appState: AppState().currentTimetable))
-//        }
-//    }
-//}
-//
-
+struct MyTimetableScene_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            MyTimetableScene(viewModel: TimetableViewModel(appState: AppState()))
+        }
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyTimetableScene: View {
     @State private var pushToListScene = false
-    var viewModel: TimetableViewModel
+    let viewModel: TimetableViewModel
     
     var body: some View {
         TimetableZStack(drawing: viewModel.drawing)

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -10,12 +10,12 @@ import SwiftUI
 struct MyTimetableScene: View {
     @State private var pushToListScene = false
     let viewModel: TimetableViewModel
-    
+
     var body: some View {
         TimetableZStack()
             .environmentObject(viewModel.currentTimetable)
             .environmentObject(viewModel.drawingSetting)
-        // navigate programmatically, because NavigationLink inside toolbar doesn't work
+            // navigate programmatically, because NavigationLink inside toolbar doesn't work
             .background(
                 NavigationLink(destination: MyLectureListScene(viewModel: MyLectureListViewModel(appState: viewModel.appState)), isActive: $pushToListScene) {
                     EmptyView()
@@ -28,29 +28,29 @@ struct MyTimetableScene: View {
                         NavBarButton(imageName: "nav.menu") {
                             print("menu tapped.")
                         }
-                        
+
                         Text("나의 시간표").font(STFont.title)
                         Text("(18 학점)")
                             .font(STFont.details)
                             .foregroundColor(Color(UIColor.secondaryLabel))
-                        
+
                         Spacer()
-                        
+
                         NavBarButton(imageName: "nav.list") {
                             pushToListScene = true
                         }
-                        
+
                         NavBarButton(imageName: "nav.share") {
                             print("share tapped")
                         }
-                        
+
                         NavBarButton(imageName: "nav.alarm.off") {
                             print("alarm tapped")
                         }
                     }
                 }
             }
-        
+
         let _ = debugChanges()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyTimetableScene: View {
     @State private var pushToListScene = false
-    @ObservedObject var viewModel: TimetableViewModel
+    var viewModel: TimetableViewModel
     
     var body: some View {
         TimetableZStack(drawing: viewModel.drawing)

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -9,10 +9,13 @@ import SwiftUI
 
 struct MyTimetableScene: View {
     @State private var pushToListScene = false
-
+    @ObservedObject var viewModel: TimetableViewModel
+    
     var body: some View {
-        TimetableZStack(viewModel: TimetableViewModel())
-            // navigate programmatically, because NavigationLink inside toolbar doesn't work
+        TimetableZStack(drawing: viewModel.drawing)
+            .environmentObject(viewModel.currentTimetable)
+            .environmentObject(viewModel.drawingSetting)
+        // navigate programmatically, because NavigationLink inside toolbar doesn't work
             .background(
                 NavigationLink(destination: MyLectureListScene(), isActive: $pushToListScene) {
                     EmptyView()
@@ -25,35 +28,39 @@ struct MyTimetableScene: View {
                         NavBarButton(imageName: "nav.menu") {
                             print("menu tapped.")
                         }
-
+                        
                         Text("나의 시간표").font(STFont.title)
                         Text("(18 학점)")
                             .font(STFont.details)
                             .foregroundColor(Color(UIColor.secondaryLabel))
-
+                        
                         Spacer()
-
+                        
                         NavBarButton(imageName: "nav.list") {
                             pushToListScene = true
                         }
-
+                        
                         NavBarButton(imageName: "nav.share") {
                             print("share tapped")
                         }
-
+                        
                         NavBarButton(imageName: "nav.alarm.off") {
                             print("alarm tapped")
                         }
                     }
                 }
             }
+        
+        let _ = debugChanges()
     }
 }
 
-struct MyTimetableScene_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            MyTimetableScene()
-        }
-    }
-}
+//struct MyTimetableScene_Previews: PreviewProvider {
+//    static var previews: some View {
+//        NavigationView {
+//            MyTimetableScene(currentTimetable: TimetableViewModel(appState: AppState().currentTimetable))
+//        }
+//    }
+//}
+//
+

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -17,7 +17,7 @@ struct MyTimetableScene: View {
             .environmentObject(viewModel.drawingSetting)
         // navigate programmatically, because NavigationLink inside toolbar doesn't work
             .background(
-                NavigationLink(destination: MyLectureListScene(), isActive: $pushToListScene) {
+                NavigationLink(destination: MyLectureListScene(viewModel: MyLectureListViewModel(appState: viewModel.appState)), isActive: $pushToListScene) {
                     EmptyView()
                 }
             )

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -1,0 +1,30 @@
+//
+//  ReviewScene.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/25.
+//
+
+import SwiftUI
+
+struct ReviewScene: View {
+    // for test
+    @ObservedObject var viewModel: ReviewViewModel
+    
+    var body: some View {
+        Button{
+            viewModel.updateTimetable(timeTable: AppState.CurrentTimetable())
+        } label: {
+            Text("Change current timetable")
+        }
+        
+        let _ = debugChanges()
+    }
+}
+
+struct ReviewScene_Previews: PreviewProvider {
+    static var previews: some View {
+        let appState = AppState()
+        ReviewScene(viewModel: ReviewViewModel(appState: appState))
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -10,14 +10,14 @@ import SwiftUI
 struct ReviewScene: View {
     // for test
     let viewModel: ReviewViewModel
-    
+
     var body: some View {
-        Button{
+        Button {
             viewModel.updateTimetable(timeTable: Timetable(lectures: []))
         } label: {
             Text("Change current timetable")
         }
-        
+
         let _ = debugChanges()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -13,7 +13,7 @@ struct ReviewScene: View {
     
     var body: some View {
         Button{
-            viewModel.updateTimetable(timeTable: AppState.CurrentTimetable())
+            viewModel.updateTimetable(timeTable: Timetable(lectures: []))
         } label: {
             Text("Change current timetable")
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ReviewScene: View {
     // for test
-    var viewModel: ReviewViewModel
+    let viewModel: ReviewViewModel
     
     var body: some View {
         Button{

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ReviewScene: View {
     // for test
-    @ObservedObject var viewModel: ReviewViewModel
+    var viewModel: ReviewViewModel
     
     var body: some View {
         Button{

--- a/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
@@ -1,0 +1,33 @@
+//
+//  SettingScene.swift
+//  SNUTT
+//
+//  Created by Jinsup Keum on 2022/06/24.
+//
+
+import SwiftUI
+
+struct SettingScene: View {
+    @ObservedObject var viewModel: SettingViewModel
+    
+    var body: some View {
+        Button{
+            viewModel.updateCurrentUser(user: AppState.CurrentUser())
+        } label: {
+            Text("Change current user")
+        }
+        
+        let _ = debugChanges()
+    }
+}
+
+struct SettingScene_Previews: PreviewProvider {
+    static var previews: some View {
+        let appState = AppState()
+        NavigationView {
+            TabView {
+                SettingScene(viewModel: SettingViewModel(appState: appState))
+            }
+        }
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
@@ -12,7 +12,7 @@ struct SettingScene: View {
     
     var body: some View {
         Button{
-            viewModel.updateCurrentUser(user: AppState.CurrentUser())
+            viewModel.updateCurrentUser(user: User())
         } label: {
             Text("Change current user")
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 struct SettingScene: View {
     let viewModel: SettingViewModel
-    
+
     var body: some View {
-        Button{
+        Button {
             viewModel.updateCurrentUser(user: User())
         } label: {
             Text("Change current user")
         }
-        
+
         let _ = debugChanges()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingScene: View {
-    @ObservedObject var viewModel: SettingViewModel
+    var viewModel: SettingViewModel
     
     var body: some View {
         Button{

--- a/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingScene: View {
-    var viewModel: SettingViewModel
+    let viewModel: SettingViewModel
     
     var body: some View {
         Button{


### PR DESCRIPTION
얘기했던 방식으로 AppState - ViewModel - View 데이터 플로우를 수정했습니다. View의 렌더링을 디버깅해보니 stateless View들은 각 View 안에서 참조하는 ViewModel 값이 변경될 때만 다시 렌더링되는 것 같습니다. AppState의 @published 변수가 바뀐다고 해서 모든 뷰가 리렌더링 되지는 않네요.

https://user-images.githubusercontent.com/54926767/175579822-23f9e2d7-a7ae-47d4-a0f2-a5f93a55c6bc.mov

데이터 플로우는 만들었으나, 아직 수정할 사항이 있습니다.
~~1. AppState 안의 class 데이터 타입들을 AppState 바깥으로, Model로 빼내기~~
~~2. `SNUTTApp.swift`에서 TabItem 선언 방식 바꾸기~~
3. 그 외에 부자연스러운 것 수정..
아침에 마저 해보겠습니다..

그리고 Workspace에 project를 추가했습니다.