### PR TITLE
Make AppState Singleton [SNUTT-456]

### DIFF
--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		BEDF507527F4289B00CDCC13 /* Lecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507427F4289B00CDCC13 /* Lecture.swift */; };
 		BEDF507727F42D1100CDCC13 /* STFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507627F42D1100CDCC13 /* STFont.swift */; };
 		BEDF507927F42D7500CDCC13 /* STColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507827F42D7500CDCC13 /* STColor.swift */; };
+		BEF7871A286632C700010ED2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF78719286632C700010ED2 /* ContentView.swift */; };
+		BEF7871C2866349F00010ED2 /* TabScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF7871B2866349F00010ED2 /* TabScene.swift */; };
 		DC2915992865D69700FE5F9A /* MyLectureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915982865D69700FE5F9A /* MyLectureListViewModel.swift */; };
 		DC29159B2865F95100FE5F9A /* SettingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159A2865F95100FE5F9A /* SettingScene.swift */; };
 		DC29159D2865FA2800FE5F9A /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */; };
@@ -76,6 +78,8 @@
 		BEDF507427F4289B00CDCC13 /* Lecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lecture.swift; sourceTree = "<group>"; };
 		BEDF507627F42D1100CDCC13 /* STFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STFont.swift; sourceTree = "<group>"; };
 		BEDF507827F42D7500CDCC13 /* STColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STColor.swift; sourceTree = "<group>"; };
+		BEF78719286632C700010ED2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BEF7871B2866349F00010ED2 /* TabScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScene.swift; sourceTree = "<group>"; };
 		DC2915982865D69700FE5F9A /* MyLectureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLectureListViewModel.swift; sourceTree = "<group>"; };
 		DC29159A2865F95100FE5F9A /* SettingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingScene.swift; sourceTree = "<group>"; };
 		DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
@@ -242,6 +246,7 @@
 			isa = PBXGroup;
 			children = (
 				DC860F4827E5C87D0068C94B /* SNUTTApp.swift */,
+				BEF78719286632C700010ED2 /* ContentView.swift */,
 				DCD41A6D27E5CDCA00CF380E /* Components */,
 				DCD41A6C27E5CDBE00CF380E /* Scenes */,
 			);
@@ -251,6 +256,7 @@
 		DCD41A6C27E5CDBE00CF380E /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
+				BEF7871B2866349F00010ED2 /* TabScene.swift */,
 				BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */,
 				BEDF507227F427FA00CDCC13 /* MyLectureListScene.swift */,
 				DC29159A2865F95100FE5F9A /* SettingScene.swift */,
@@ -439,6 +445,7 @@
 				DC29159B2865F95100FE5F9A /* SettingScene.swift in Sources */,
 				BE7E230327FF3C38004DC202 /* NavBarButton.swift in Sources */,
 				BEDF506F27EB744A00CDCC13 /* LectureDetails.swift in Sources */,
+				BEF7871C2866349F00010ED2 /* TabScene.swift in Sources */,
 				BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */,
 				DCD41A6027E5CC7700CF380E /* Timetable.swift in Sources */,
 				B87431CB283B5A7300D78C59 /* SNUTTViewModel.swift in Sources */,
@@ -457,6 +464,7 @@
 				DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */,
 				BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */,
 				DCD41A7227E5CE1D00CF380E /* TimetableViewModel.swift in Sources */,
+				BEF7871A286632C700010ED2 /* ContentView.swift in Sources */,
 				BEDF507927F42D7500CDCC13 /* STColor.swift in Sources */,
 				DCD41A6A27E5CD8700CF380E /* TimetableApi.swift in Sources */,
 			);

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -8,21 +8,30 @@
 import Combine
 import SwiftUI
 
-class AppState: ObservableObject {
-    @Published var currentUser = CurrentUser()
-    @Published var currentTimetable = CurrentTimetable()
-    @Published var setting = Setting()
-    @Published var system = System()
-
-    @Published var selectedTab: SelectedTab = .timetable
+class AppState {
+    static var of: AppState = AppState()
+    var currentUser = CurrentUser()
+    var currentTimetable = CurrentTimetable()
+    var setting = Setting()
+    var timetableSetting = DrawingSetting()
+    var system = System()
 }
 
 extension AppState {
-    enum SelectedTab {
+    
+    enum TabType: String {
         case timetable
         case search
         case review
         case settings
+        
+        var onImageName: String {
+            "tab.\(rawValue).on"
+        }
+
+        var offImageName: String {
+            "tab.\(rawValue).off"
+        }
     }
 
     enum State {
@@ -45,7 +54,7 @@ extension AppState {
         var timetable = Timetable()
 
         // for test(will be removed)
-        var lectures = [
+        @Published var lectures = [
             Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
                 TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
                 TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
@@ -76,10 +85,10 @@ extension AppState {
     }
 
     class DrawingSetting: ObservableObject {
-        let minHour: Int = 8
-        let maxHour: Int = 19
+        @Published var minHour: Int = 8
+        @Published var maxHour: Int = 19
 
-        let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
+        @Published var visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
 
         var hourCount: Int {
             maxHour - minHour + 1
@@ -93,8 +102,9 @@ extension AppState {
 
 // 시스템 상태
 extension AppState {
-    struct System {
-        var showActivityIndicator = false
-        var state: State = .success
+    class System: ObservableObject {
+        @Published var showActivityIndicator = false
+        @Published var state: State = .success
+        @Published var selectedTab: TabType = .timetable
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -5,21 +5,12 @@
 //  Created by Jinsup Keum on 2022/06/24.
 //
 
-import Foundation
 import SwiftUI
 
 class MyLectureListViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
-
-    var currentTimetable: AppState.CurrentTimetable {
-        state.currentTimetable
-    }
+    var currentTimetable = AppState.of.currentTimetable
 
     func updateTimetable(timeTable: AppState.CurrentTimetable) {
-        state.currentTimetable = timeTable
-    }
-
-    init(appState: AppState) {
-        state = appState
+        AppState.of.currentTimetable = timeTable
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -9,17 +9,9 @@ import Foundation
 import SwiftUI
 
 class ReviewViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
-
-    var currentTimetable: AppState.CurrentTimetable {
-        state.currentTimetable
-    }
+    var currentTimetable = AppState.of.currentTimetable
 
     func updateTimetable(timeTable: AppState.CurrentTimetable) {
-        state.currentTimetable = timeTable
-    }
-
-    init(appState: AppState) {
-        state = appState
+        AppState.of.currentTimetable = timeTable
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -9,17 +9,9 @@ import Foundation
 import SwiftUI
 
 class SettingViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
-
-    var currentUser: AppState.CurrentUser {
-        state.currentUser
-    }
+    var currentUser = AppState.of.currentUser
 
     func updateCurrentUser(user: AppState.CurrentUser) {
-        state.currentUser = user
-    }
-
-    init(appState: AppState) {
-        state = appState
+        AppState.of.currentUser = user
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -29,27 +29,27 @@ class TimetableViewModel: ObservableObject {
         state = appState
     }
 
-    struct TimetableDrawing {
+    struct TimetablePainter {
         /// 시간표 맨 왼쪽, 시간들을 나타내는 열의 너비
-        let hourWidth: CGFloat = 20
+        static let hourWidth: CGFloat = 20
 
         /// 시간표 맨 위쪽, 날짜를 나타내는 행의 높이
-        let weekdayHeight: CGFloat = 25
+        static let weekdayHeight: CGFloat = 25
 
         /// 컨테이너의 사이즈가 주어졌을 때, 하루의 너비를 계산한다.
-        func getWeekWidth(in containerSize: CGSize, weekCount: Int) -> CGFloat {
+        static func getWeekWidth(in containerSize: CGSize, weekCount: Int) -> CGFloat {
             return (containerSize.width - hourWidth) / CGFloat(weekCount)
         }
 
         /// 컨테이너의 사이즈가 주어졌을 때, 한 시간의 높이를 계산한다.
-        func getHourHeight(in containerSize: CGSize, hourCount: Int) -> CGFloat {
+        static func getHourHeight(in containerSize: CGSize, hourCount: Int) -> CGFloat {
             return (containerSize.height - weekdayHeight) / CGFloat(hourCount)
         }
 
         /// 주어진 `TimePlace` 블록의 좌표(오프셋)를 구한다.
         ///
         /// 주어진 `TimePlace`를 시간표에 표시할 수 없는 경우(e.g. 시간이나 요일 범위에서 벗어난 경우 등)에는 `nil`을 리턴한다.
-        func getOffset(of timePlace: TimePlace, in containerSize: CGSize, drawingSetting: AppState.DrawingSetting) -> CGPoint? {
+        static func getOffset(of timePlace: TimePlace, in containerSize: CGSize, drawingSetting: AppState.DrawingSetting) -> CGPoint? {
             if containerSize == .zero {
                 return nil
             }
@@ -66,7 +66,7 @@ class TimetableViewModel: ObservableObject {
         }
 
         /// 주어진 `TimePlace`블록의 높이를 구한다.
-        func getHeight(of timePlace: TimePlace, in containerSize: CGSize, hourCount: Int) -> CGFloat {
+        static func getHeight(of timePlace: TimePlace, in containerSize: CGSize, hourCount: Int) -> CGFloat {
             return timePlace.len * getHourHeight(in: containerSize, hourCount: hourCount)
         }
 

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -5,28 +5,40 @@
 //  Created by Jinsup Keum on 2022/03/19.
 //
 
-import SwiftUI
 import UIKit
 
 class TimetableViewModel: ObservableObject {
-    @ObservedObject private var state: AppState
-
-    var drawing = TimetableDrawing()
-
-    var currentTimetable: AppState.CurrentTimetable {
-        state.currentTimetable
-    }
-
-    var drawingSetting: AppState.DrawingSetting {
-        state.setting.drawing
-    }
+    var currentTimetable = AppState.of.currentTimetable
+    var drawingSetting = AppState.of.timetableSetting
 
     func updateTimetable(timeTable: AppState.CurrentTimetable) {
-        state.currentTimetable = timeTable
+        AppState.of.currentTimetable = timeTable
     }
-
-    init(appState: AppState) {
-        state = appState
+    
+    func updateDrawingSettings() {
+        drawingSetting.minHour = Int.random(in: 0...9)
+        drawingSetting.maxHour = Int.random(in: 18...23)
+    }
+    
+    func updateCurrentTimetable() {
+        currentTimetable.lectures = [
+            Lecture(id: 1, title: "강의-\(Int.random(in: 0...50))", instructor: "전병곤", timePlaces: [
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: Double.random(in: 0.5...3), place: "302-123"),
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: 1.5, place: "302-123"),
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: 1.5, place: "302-123"),
+            ]),
+            Lecture(id: 2, title: "강의-\(Int.random(in: 0...50))", instructor: "전병곤", timePlaces: [
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: Double.random(in: 0.5...3), place: "302-123"),
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: 1.5, place: "302-123"),
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: 1.5, place: "302-123"),
+            ]),
+            Lecture(id: 3, title: "강의-\(Int.random(in: 0...50))", instructor: "전병곤", timePlaces: [
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: Double.random(in: 0.5...3), place: "302-123"),
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: 1.5, place: "302-123"),
+                TimePlace(day: Weekday(rawValue: Int.random(in: 1...4))!, start: Double.random(in: 1...10), len: 1.5, place: "302-123"),
+            ]),
+        ]
+        
     }
 
     struct TimetablePainter {

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct TimetableBlocksLayer: View {
-    @EnvironmentObject var drawingSetting: AppState.DrawingSetting
-    @EnvironmentObject var currentTimetable: AppState.CurrentTimetable
     typealias Painter = TimetableViewModel.TimetablePainter
+    @ObservedObject var drawingSetting = AppState.of.timetableSetting
+    @ObservedObject var currentTimetable = AppState.of.currentTimetable
 
     var body: some View {
         GeometryReader { reader in

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -8,17 +8,17 @@
 import SwiftUI
 
 struct TimetableBlocksLayer: View {
-    let drawing: TimetableViewModel.TimetableDrawing
     @EnvironmentObject var drawingSetting: AppState.DrawingSetting
     @EnvironmentObject var currentTimetable: AppState.CurrentTimetable
+    typealias Painter = TimetableViewModel.TimetablePainter
 
     var body: some View {
         GeometryReader { reader in
             ForEach(currentTimetable.lectures) { lecture in
                 ForEach(lecture.timePlaces) { timePlace in
-                    if let offsetPoint = drawing.getOffset(of: timePlace, in: reader.size, drawingSetting: drawingSetting) {
+                    if let offsetPoint = Painter.getOffset(of: timePlace, in: reader.size, drawingSetting: drawingSetting) {
                         TimetableBlock(lecture: lecture, timePlace: timePlace)
-                            .frame(width: drawing.getWeekWidth(in: reader.size, weekCount: drawingSetting.weekCount), height: drawing.getHeight(of: timePlace, in: reader.size, hourCount: drawingSetting.hourCount), alignment: .center)
+                            .frame(width: Painter.getWeekWidth(in: reader.size, weekCount: drawingSetting.weekCount), height: Painter.getHeight(of: timePlace, in: reader.size, hourCount: drawingSetting.hourCount), alignment: .center)
                             .offset(x: offsetPoint.x, y: offsetPoint.y)
                     }
                 }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct TimetableGridLayer: View {
-    @EnvironmentObject var drawingSetting: AppState.DrawingSetting
     typealias Painter = TimetableViewModel.TimetablePainter
+    @ObservedObject var drawingSetting = AppState.of.timetableSetting
 
     var body: some View {
         GeometryReader { reader in
@@ -97,8 +97,8 @@ struct TimetableGridLayer: View {
 }
 
 //
-// struct TimetableGrid_Previews: PreviewProvider {
-//    static var previews: some View {
-//        TimetableGridLayer(viewModel: TimetableViewModel())
-//    }
-// }
+ struct TimetableGrid_Previews: PreviewProvider {
+    static var previews: some View {
+        TimetableGridLayer()
+    }
+ }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableGridLayer.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct TimetableGridLayer: View {
-    let drawing: TimetableViewModel.TimetableDrawing
     @EnvironmentObject var drawingSetting: AppState.DrawingSetting
+    typealias Painter = TimetableViewModel.TimetablePainter
 
     var body: some View {
         GeometryReader { reader in
@@ -30,10 +30,10 @@ struct TimetableGridLayer: View {
 
     /// 하루 간격의 수직선
     func verticalPaths(in containerSize: CGSize) -> Path {
-        let weekWidth = drawing.getWeekWidth(in: containerSize, weekCount: drawingSetting.weekCount)
+        let weekWidth = Painter.getWeekWidth(in: containerSize, weekCount: drawingSetting.weekCount)
         return Path { path in
             for i in 0 ..< drawingSetting.weekCount {
-                let x = drawing.hourWidth + CGFloat(i) * weekWidth
+                let x = Painter.hourWidth + CGFloat(i) * weekWidth
                 path.move(to: CGPoint(x: x, y: 0))
                 path.addLine(to: CGPoint(x: x, y: containerSize.height))
             }
@@ -42,10 +42,10 @@ struct TimetableGridLayer: View {
 
     /// 한 시간 간격의 수평선
     func horizontalHourlyPaths(in containerSize: CGSize) -> Path {
-        let hourHeight = drawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
+        let hourHeight = Painter.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
         return Path { path in
             for i in 0 ..< drawingSetting.hourCount {
-                let y = drawing.weekdayHeight + CGFloat(i) * hourHeight
+                let y = Painter.weekdayHeight + CGFloat(i) * hourHeight
                 path.move(to: CGPoint(x: 0, y: y))
                 path.addLine(to: CGPoint(x: containerSize.width, y: y))
             }
@@ -54,11 +54,11 @@ struct TimetableGridLayer: View {
 
     /// 30분 간격의 수평선
     func horizontalHalfHourlyPaths(in containerSize: CGSize) -> Path {
-        let hourHeight = drawing.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
+        let hourHeight = Painter.getHourHeight(in: containerSize, hourCount: drawingSetting.hourCount)
         return Path { path in
             for i in 0 ..< drawingSetting.hourCount {
-                let y = drawing.weekdayHeight + CGFloat(i) * hourHeight + hourHeight / 2
-                path.move(to: CGPoint(x: 0 + drawing.hourWidth, y: y))
+                let y = Painter.weekdayHeight + CGFloat(i) * hourHeight + hourHeight / 2
+                path.move(to: CGPoint(x: 0 + Painter.hourWidth, y: y))
                 path.addLine(to: CGPoint(x: containerSize.width, y: y))
             }
         }
@@ -74,10 +74,10 @@ struct TimetableGridLayer: View {
                     .font(STFont.details)
                     .foregroundColor(Color(UIColor.secondaryLabel))
                     .frame(maxWidth: .infinity)
-                    .frame(height: drawing.weekdayHeight)
+                    .frame(height: Painter.weekdayHeight)
             }
         }
-        .padding(.leading, drawing.hourWidth)
+        .padding(.leading, Painter.hourWidth)
     }
 
     /// 시간표 맨 왼쪽, 시간들을 나타내는 행
@@ -88,11 +88,11 @@ struct TimetableGridLayer: View {
                     .font(STFont.details)
                     .foregroundColor(Color(UIColor.secondaryLabel))
                     .padding(.top, 5)
-                    .frame(width: drawing.hourWidth)
+                    .frame(width: Painter.hourWidth)
                     .frame(maxHeight: .infinity, alignment: .top)
             }
         }
-        .padding(.top, drawing.weekdayHeight)
+        .padding(.top, Painter.weekdayHeight)
     }
 }
 

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
@@ -8,12 +8,10 @@
 import SwiftUI
 
 struct TimetableZStack: View {
-    let drawing: TimetableViewModel.TimetableDrawing
-
     var body: some View {
         ZStack {
-            TimetableGridLayer(drawing: drawing)
-            TimetableBlocksLayer(drawing: drawing)
+            TimetableGridLayer()
+            TimetableBlocksLayer()
         }
 
         let _ = debugChanges()

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
@@ -18,9 +18,8 @@ struct TimetableZStack: View {
     }
 }
 
-//
-// struct TimetableStack_Previews: PreviewProvider {
-//    static var previews: some View {
-////        TimetableZStack(viewModel: TimetableViewModel())
-//    }
-// }
+ struct TimetableStack_Previews: PreviewProvider {
+    static var previews: some View {
+        TimetableZStack()
+    }
+ }

--- a/SNUTT-2022/SNUTT/Views/ContentView.swift
+++ b/SNUTT-2022/SNUTT/Views/ContentView.swift
@@ -1,0 +1,61 @@
+//
+//  ContentView.swift
+//  SNUTT
+//
+//  Created by 박신홍 on 2022/06/25.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @ObservedObject var systemState = AppState.of.system
+    
+    var body: some View {
+        TabView(selection: $systemState.selectedTab) {
+            TabScene(tabType: .timetable) {
+                MyTimetableScene()
+            }
+            TabScene(tabType: .search) {
+                MyLectureListScene()
+            }
+            TabScene(tabType: .review) {
+                ReviewScene()
+            }
+            TabScene(tabType: .settings) {
+                SettingScene()
+            }
+        }
+        .accentColor(Color(UIColor.label))
+        .onAppear {
+            setTabBarStyle()
+            setNavBarStyle()
+        }
+        let _ = debugChanges()
+    }
+    
+    /// Globally set the background color of the tab bar to white.
+    private func setTabBarStyle() {
+        let appearance = UITabBarAppearance()
+        appearance.backgroundColor = .white
+        UITabBar.appearance().standardAppearance = appearance
+        if #available(iOS 15.0, *) {
+            UITabBar.appearance().scrollEdgeAppearance = appearance
+        }
+    }
+    
+    /// Globally set the background color of the nav bar to white.
+    private func setNavBarStyle() {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .white
+        UINavigationBar.appearance().standardAppearance = appearance
+        if #available(iOS 15.0, *) {
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -9,76 +9,10 @@ import SwiftUI
 
 @main
 struct SNUTTApp: App {
-    @StateObject var appState = AppState()
-
     var body: some Scene {
-        let tabItems: [TabItem] = [
-            TabItem(id: .timetable, view: AnyView(MyTimetableScene(viewModel: TimetableViewModel(appState: appState))), symbolName: .timetable),
-            TabItem(id: .search, view: AnyView(MyLectureListScene()), symbolName: .search),
-            TabItem(id: .review, view: AnyView(ReviewScene(viewModel: ReviewViewModel(appState: appState))), symbolName: .review),
-            TabItem(id: .settings, view: AnyView(SettingScene(viewModel: SettingViewModel(appState: appState))), symbolName: .settings),
-        ]
-
         WindowGroup {
-            // 임시 Entry Point
-            TabView(selection: $appState.selectedTab) {
-                ForEach(tabItems) { tab in
-                    NavigationView {
-                        tab.view
-                    }
-                    .accentColor(Color(UIColor.label))
-                    .tabItem {
-                        Image(appState.selectedTab == tab.id ? tab.onImageName : tab.offImageName)
-                    }
-                }
-            }
-            .onAppear {
-                setTabBarStyle()
-                setNavBarStyle()
-            }
+            ContentView()
         }
-    }
-
-    /// Globally set the background color of the tab bar to white.
-    private func setTabBarStyle() {
-        let appearance = UITabBarAppearance()
-        appearance.backgroundColor = .white
-        UITabBar.appearance().standardAppearance = appearance
-        if #available(iOS 15.0, *) {
-            UITabBar.appearance().scrollEdgeAppearance = appearance
-        }
-    }
-
-    /// Globally set the background color of the nav bar to white.
-    private func setNavBarStyle() {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .white
-        UINavigationBar.appearance().standardAppearance = appearance
-        if #available(iOS 15.0, *) {
-            UINavigationBar.appearance().scrollEdgeAppearance = appearance
-        }
-    }
-}
-
-/// A simple wrapper struct that represents a tab view item.
-struct TabItem: Identifiable {
-    enum SymbolName: String {
-        case timetable
-        case search
-        case review
-        case settings
-    }
-
-    let id: AppState.SelectedTab
-    let view: AnyView
-    let symbolName: SymbolName
-
-    var onImageName: String {
-        "tab.\(symbolName.rawValue).on"
-    }
-
-    var offImageName: String {
-        "tab.\(symbolName.rawValue).off"
     }
 }
 

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
@@ -7,18 +7,20 @@
 
 import SwiftUI
 
+let lectureList = [
+    Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
+        TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
+        TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
+        TimePlace(day: Weekday(rawValue: 3)!, start: 4.70, len: 1.5, place: "302-123"),
+    ]),
+    Lecture(id: 2, title: "컴퓨터구조", instructor: "김진수", timePlaces: [
+        TimePlace(day: Weekday(rawValue: 2)!, start: 7.5, len: 1.5, place: "302-123"),
+        TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
+    ]),
+]
+
 struct MyLectureListScene: View {
-    let myDummyLectureList = [
-        Lecture(id: 1, title: "컴파일러", instructor: "전병곤", timePlaces: [
-            TimePlace(day: Weekday(rawValue: 1)!, start: 5.5, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 3)!, start: 3.15, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 3)!, start: 4.70, len: 1.5, place: "302-123"),
-        ]),
-        Lecture(id: 2, title: "컴퓨터구조", instructor: "김진수", timePlaces: [
-            TimePlace(day: Weekday(rawValue: 2)!, start: 7.5, len: 1.5, place: "302-123"),
-            TimePlace(day: Weekday(rawValue: 4)!, start: 7.5, len: 1.5, place: "302-123"),
-        ]),
-    ]
+    let myDummyLectureList = lectureList
 
     var body: some View {
         LectureList(lectures: myDummyLectureList)

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -12,9 +12,7 @@ struct MyTimetableScene: View {
     @ObservedObject var viewModel: TimetableViewModel
 
     var body: some View {
-        TimetableZStack(drawing: viewModel.drawing)
-            .environmentObject(viewModel.currentTimetable)
-            .environmentObject(viewModel.drawingSetting)
+        TimetableZStack()
             // navigate programmatically, because NavigationLink inside toolbar doesn't work
             .background(
                 NavigationLink(destination: MyLectureListScene(), isActive: $pushToListScene) {

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -33,7 +33,15 @@ struct MyTimetableScene: View {
                             .foregroundColor(Color(UIColor.secondaryLabel))
 
                         Spacer()
-
+                        
+                        Button {
+                            viewModel.updateDrawingSettings()
+                            viewModel.updateCurrentTimetable()
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .frame(width: 30, height: 45)
+                        
                         NavBarButton(imageName: "nav.list") {
                             pushToListScene = true
                         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyTimetableScene: View {
     @State private var pushToListScene = false
-    @ObservedObject var viewModel: TimetableViewModel
+    @StateObject var viewModel = TimetableViewModel()
 
     var body: some View {
         TimetableZStack()
@@ -53,11 +53,11 @@ struct MyTimetableScene: View {
     }
 }
 
-// struct MyTimetableScene_Previews: PreviewProvider {
-//    static var previews: some View {
-//        NavigationView {
-//            MyTimetableScene(currentTimetable: TimetableViewModel(appState: AppState().currentTimetable))
-//        }
-//    }
-// }
-//
+ struct MyTimetableScene_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            MyTimetableScene()
+        }
+    }
+ }
+

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ReviewScene: View {
     // for test
-    @ObservedObject var viewModel: ReviewViewModel
+    @StateObject var viewModel = ReviewViewModel()
 
     var body: some View {
         Button {
@@ -24,7 +24,6 @@ struct ReviewScene: View {
 
 struct ReviewScene_Previews: PreviewProvider {
     static var previews: some View {
-        let appState = AppState()
-        ReviewScene(viewModel: ReviewViewModel(appState: appState))
+        ReviewScene()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SettingScene.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingScene: View {
-    @ObservedObject var viewModel: SettingViewModel
+    @StateObject var viewModel = SettingViewModel()
 
     var body: some View {
         Button {
@@ -23,10 +23,9 @@ struct SettingScene: View {
 
 struct SettingScene_Previews: PreviewProvider {
     static var previews: some View {
-        let appState = AppState()
         NavigationView {
             TabView {
-                SettingScene(viewModel: SettingViewModel(appState: appState))
+                SettingScene()
             }
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/TabScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TabScene.swift
@@ -1,0 +1,41 @@
+//
+//  TabScene.swift
+//  SNUTT
+//
+//  Created by 박신홍 on 2022/06/25.
+//
+
+import SwiftUI
+
+struct TabScene<Content>: View where Content: View {
+    var systemState = AppState.of.system
+    let tabType: AppState.TabType
+    @State var isViewDisplayed = false
+    @ViewBuilder var content: () -> Content
+    
+    var onImageName: String {
+        "tab.\(tabType.rawValue).on"
+    }
+
+    var offImageName: String {
+        "tab.\(tabType.rawValue).off"
+    }
+    
+    var body: some View {
+        NavigationView {
+            self.content()
+        }
+        .accentColor(Color(UIColor.label))
+        .tabItem {
+            Image(self.isViewDisplayed ? onImageName : offImageName)
+        }
+        .onAppear {
+            self.isViewDisplayed = true
+        }
+        .onDisappear {
+            self.isViewDisplayed = false
+        }
+        .tag(tabType)
+    }
+}
+


### PR DESCRIPTION
- #76 를 리뷰하다가, AppState를 singleton으로 만들면 더 깔끔해질 것 같아서 개인적으로 실험을 조금 해보았습니다. 그 외에도 제가 리뷰에 남겼던 제안사항들이 잘 작동하는지 확인하기 위해 해당 내용도 반영해보았습니다.
- 전반적인 data flow는 SNUTT-456와 비슷하지만, AppState를 singleton(Non-`Observable`)으로 만들고 EnvironmentObject를 사용한 부분을 ObservedObject로 바꿨다는 점이 조금 다릅니다.

이렇게 했을 때 장점은,
- AppState를 사용하는 곳(ViewModel, Service 등)마다 매번 constructor로 전달해주지 않아도 됨
- EnvironmentObject(EO)를 주입하는 뷰 - EO를 사용하는 뷰 사이에 여러 View가 존재할 때, 이 모든 뷰의 Preview를 렌더링할 때마다 EO를 주입해주어야 하는 번거로움이 사라짐
- ViewModel을 pure class로 선언할 수 있음: View는 AppState의 변화에 반응하기만 하면 되고, ViewModel은 AppState를 변화시키기만 하면 되므로, ViewModel을 Observable로 만들어서 View에서 구독하고 있을 필요가 없어집니다.

# 상태 변화 데모

이 방식으로 구현해도, AppState가 바뀌었을 때 정확히 리렌더링되어야 하는 View만 리렌더링되는 것을 확인할 수 있었습니다.

https://user-images.githubusercontent.com/33917774/175753035-4fc685ae-ab11-4e84-b8ae-55da47321cc3.mov



