### PR TITLE
중복된 강의 덮어쓰기 구현 [SNUTT-455]

### DIFF
--- a/SNUTT/SNUTT/STErrorCode.swift
+++ b/SNUTT/SNUTT/STErrorCode.swift
@@ -101,7 +101,6 @@ public enum STErrorCode: Int {
              .FB_ID_WITH_SOMEONE_ELSE,
              .WRONG_SEMESTER,
              .NOT_CUSTOM_LECTURE,
-             .LECTURE_TIME_OVERLAP,
              .IS_CUSTOM_LECTURE,
              .USER_HAS_NO_FCM_KEY:
             return "잘못된 요청"
@@ -112,6 +111,8 @@ public enum STErrorCode: Int {
              .USER_NOT_FOUND,
              .COLORLIST_NOT_FOUND:
             return "찾지 못함"
+        case .LECTURE_TIME_OVERLAP:
+            return "시간대 겹침"
         }
     }
 

--- a/SNUTT/SNUTT/STLecture.swift
+++ b/SNUTT/SNUTT/STLecture.swift
@@ -119,8 +119,7 @@ struct STLecture {
 
         let listData = data["class_time_json"].arrayValue
         for it in listData {
-            let startPeriod = isCustomLecture ? it["start"].doubleValue
-            let time = STTime(day: it["day"].intValue, startPeriod: startPeriod, duration: it["len"].doubleValue)
+            let time = STTime(day: it["day"].intValue, startPeriod: it["start"].doubleValue, duration: it["len"].doubleValue)
             let singleClass = STSingleClass(time: time, place: it["place"].stringValue)
             classList.append(singleClass)
         }

--- a/SNUTT/SNUTT/STLectureRouter.swift
+++ b/SNUTT/SNUTT/STLectureRouter.swift
@@ -17,7 +17,7 @@ enum STLectureRouter: STRouter {
     case addCustomLecture(timetableId: String, lecture: STLecture, isForced: Bool)
     case addLecture(timetableId: String, lectureId: String, isForced: Bool)
     case deleteLecture(timetableId: String, lecture: STLecture)
-    case updateLecture(timetableId: String, oldLecture: STLecture, newLecture: STLecture)
+    case updateLecture(timetableId: String, oldLecture: STLecture, newLecture: STLecture, isForced: Bool)
     case resetLecture(timetableId: String, lectureId: String)
 
     var method: HTTPMethod {
@@ -41,7 +41,7 @@ enum STLectureRouter: STRouter {
             return "/\(timetableId)/lecture/\(lectureId)"
         case let .deleteLecture(timetableId, lecture):
             return "/\(timetableId)/lecture/\(lecture.id ?? "")"
-        case let .updateLecture(timetableId, curLecture, _):
+        case let .updateLecture(timetableId, curLecture, _, _):
             return "/\(timetableId)/lecture/\(curLecture.id ?? "")"
         case let .resetLecture(timetableId, lectureId):
             return "/\(timetableId)/lecture/\(lectureId)/reset"
@@ -53,14 +53,14 @@ enum STLectureRouter: STRouter {
         case let .addCustomLecture(_, lecture, isForced):
             var dict = lecture.toDictionary()
             dict.removeValue(forKey: "id")
-            dict.updateValue(isForced, forKey: "is_forced")
+            dict["is_forced"] = isForced
             return dict
         case let .addLecture(_, _, isForced):
             let dict = ["is_forced": isForced]
             return dict
         case .deleteLecture:
             return nil
-        case let .updateLecture(_, oldLecture, newLecture):
+        case let .updateLecture(_, oldLecture, newLecture, isForced):
             var dict: [String: Any] = [:]
             let oldDict = oldLecture.toDictionary()
             let newDict = newLecture.toDictionary()
@@ -76,6 +76,7 @@ enum STLectureRouter: STRouter {
                     dict[key] = newVal
                 }
             }
+            dict["is_forced"] = isForced
             return dict
         case .resetLecture:
             return nil

--- a/SNUTT/SNUTT/STLectureRouter.swift
+++ b/SNUTT/SNUTT/STLectureRouter.swift
@@ -14,8 +14,8 @@ enum STLectureRouter: STRouter {
     static let baseURLString = STConfig.sharedInstance.baseURL + "/tables"
     static let shouldAddToken: Bool = true
 
-    case addCustomLecture(timetableId: String, lecture: STLecture)
-    case addLecture(timetableId: String, lectureId: String)
+    case addCustomLecture(timetableId: String, lecture: STLecture, isForced: Bool)
+    case addLecture(timetableId: String, lectureId: String, isForced: Bool)
     case deleteLecture(timetableId: String, lecture: STLecture)
     case updateLecture(timetableId: String, oldLecture: STLecture, newLecture: STLecture)
     case resetLecture(timetableId: String, lectureId: String)
@@ -35,9 +35,9 @@ enum STLectureRouter: STRouter {
 
     var path: String {
         switch self {
-        case let .addCustomLecture(timetableId, _):
+        case let .addCustomLecture(timetableId, _, _):
             return "/\(timetableId)/lecture"
-        case let .addLecture(timetableId, lectureId):
+        case let .addLecture(timetableId, lectureId, _):
             return "/\(timetableId)/lecture/\(lectureId)"
         case let .deleteLecture(timetableId, lecture):
             return "/\(timetableId)/lecture/\(lecture.id ?? "")"
@@ -50,12 +50,14 @@ enum STLectureRouter: STRouter {
 
     var parameters: [String: Any]? {
         switch self {
-        case let .addCustomLecture(_, lecture):
+        case let .addCustomLecture(_, lecture, isForced):
             var dict = lecture.toDictionary()
             dict.removeValue(forKey: "id")
+            dict.updateValue(isForced, forKey: "is_forced")
             return dict
-        case .addLecture:
-            return nil
+        case let .addLecture(_, _, isForced):
+            let dict = ["is_forced": isForced]
+            return dict
         case .deleteLecture:
             return nil
         case let .updateLecture(_, oldLecture, newLecture):

--- a/SNUTT/SNUTT/STNetworking.swift
+++ b/SNUTT/SNUTT/STNetworking.swift
@@ -161,13 +161,15 @@ class STNetworking {
         })
     }
 
-    static func updateLecture(_ timetable: STTimetable, oldLecture: STLecture, newLecture: STLecture, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void) {
-        let request = Alamofire.request(STLectureRouter.updateLecture(timetableId: timetable.id!, oldLecture: oldLecture, newLecture: newLecture))
+    static func updateLecture(_ timetable: STTimetable, oldLecture: STLecture, newLecture: STLecture, isForced: Bool = false, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void, confirmAction: (() -> Void)? = nil) {
+        let request = Alamofire.request(STLectureRouter.updateLecture(timetableId: timetable.id!, oldLecture: oldLecture, newLecture: newLecture, isForced: isForced))
         request.responseWithDone({ _, json in
             done(STTimetable(json: json))
         }, failure: { _ in
             failure()
-        }, showNetworkAlert: true, alertTitle: "강좌 수정 실패")
+        }, confirmAction: {
+            confirmAction?()
+        })
     }
 
     static func deleteLecture(_ timetable: STTimetable, lecture: STLecture, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void) {

--- a/SNUTT/SNUTT/STNetworking.swift
+++ b/SNUTT/SNUTT/STNetworking.swift
@@ -148,12 +148,14 @@ class STNetworking {
         })
     }
 
-    static func addLecture(_ timetable: STTimetable, lectureId: String, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void) {
+    static func addLecture(_ timetable: STTimetable, lectureId: String, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void, confirmAction: (() -> Void)? = nil) {
         let request = Alamofire.request(STLectureRouter.addLecture(timetableId: timetable.id!, lectureId: lectureId))
         request.responseWithDone({ _, json in
             done(STTimetable(json: json))
         }, failure: { _ in
             failure()
+        }, confirmAction: {
+            confirmAction?()
         })
     }
 

--- a/SNUTT/SNUTT/STNetworking.swift
+++ b/SNUTT/SNUTT/STNetworking.swift
@@ -139,17 +139,19 @@ class STNetworking {
 
     // MARK: LectureRouter
 
-    static func addCustomLecture(_ timetable: STTimetable, lecture: STLecture, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void) {
-        let request = Alamofire.request(STLectureRouter.addCustomLecture(timetableId: timetable.id!, lecture: lecture))
+    static func addCustomLecture(_ timetable: STTimetable, lecture: STLecture, isForced: Bool = false, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void, confirmAction: (() -> Void)? = nil) {
+        let request = Alamofire.request(STLectureRouter.addCustomLecture(timetableId: timetable.id!, lecture: lecture, isForced: isForced))
         request.responseWithDone({ _, json in
             done(STTimetable(json: json))
         }, failure: { _ in
             failure()
+        }, confirmAction: {
+            confirmAction?()
         })
     }
 
-    static func addLecture(_ timetable: STTimetable, lectureId: String, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void, confirmAction: (() -> Void)? = nil) {
-        let request = Alamofire.request(STLectureRouter.addLecture(timetableId: timetable.id!, lectureId: lectureId))
+    static func addLecture(_ timetable: STTimetable, lectureId: String, isForced: Bool = false, done: @escaping (STTimetable) -> Void, failure: @escaping () -> Void, confirmAction: (() -> Void)? = nil) {
+        let request = Alamofire.request(STLectureRouter.addLecture(timetableId: timetable.id!, lectureId: lectureId, isForced: isForced))
         request.responseWithDone({ _, json in
             done(STTimetable(json: json))
         }, failure: { _ in

--- a/SNUTT/SNUTT/STPeriod.swift
+++ b/SNUTT/SNUTT/STPeriod.swift
@@ -20,7 +20,7 @@ extension Double {
     /// `Double`을 분 단위로 정확하게 60진법 수로 환산한다.
     /// ex) 7.3교시 -> 15시 18분 (`7 + 8 == 15`, `0.3 * 60 == 18`)
     func periodStringPrecise() -> String {
-        let hour = Int(self)
+        let hour = Int(self) + 8
         let minute: Double = (truncatingRemainder(dividingBy: 1) * 60).rounded() // schoolbook rounding
         return "\(hour):\(Int(minute))"
     }

--- a/SNUTT/SNUTT/STTimetable.swift
+++ b/SNUTT/SNUTT/STTimetable.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftyJSON
 
 enum STAddLectureState {
-    case success, errorTime, errorSameLecture
+    case success, errorTime(STLecture), errorSameLecture
 }
 
 class STTimetable {
@@ -79,7 +79,7 @@ class STTimetable {
             for class1 in it.classList {
                 for class2 in lecture.classList {
                     if class1.time.isOverlappingWith(class2.time) {
-                        return STAddLectureState.errorTime
+                        return STAddLectureState.errorTime(it)
                     }
                 }
             }

--- a/SNUTT/SNUTT/STTimetable.swift
+++ b/SNUTT/SNUTT/STTimetable.swift
@@ -9,10 +9,6 @@
 import Foundation
 import SwiftyJSON
 
-enum STAddLectureState {
-    case success, errorTime(STLecture), errorSameLecture
-}
-
 class STTimetable {
     var lectureList: [STLecture] = []
     var quarter: STQuarter
@@ -71,35 +67,20 @@ class STTimetable {
         ]
     }
 
-    func addLecture(_ lecture: STLecture) -> STAddLectureState {
+    func addLecture(_ lecture: STLecture) {
         for it in lectureList {
             if it.isSameLecture(lecture) {
-                return STAddLectureState.errorSameLecture
+                return
             }
             for class1 in it.classList {
                 for class2 in lecture.classList {
                     if class1.time.isOverlappingWith(class2.time) {
-                        return STAddLectureState.errorTime(it)
+                        return
                     }
                 }
             }
         }
         lectureList.append(lecture)
-        return STAddLectureState.success
-    }
-
-    func overlappingLectures(with: STLecture) -> [STLecture]? {
-        var overlapping: [STLecture] = []
-        for lecture in lectureList {
-            for class1 in lecture.classList {
-                for class2 in with.classList {
-                    if class1.time.isOverlappingWith(class2.time) {
-                        overlapping.append(lecture)
-                    }
-                }
-            }
-        }
-        return overlapping
     }
 
     func indexOf(lecture: STLecture) -> Int {

--- a/SNUTT/SNUTT/STTimetable.swift
+++ b/SNUTT/SNUTT/STTimetable.swift
@@ -87,6 +87,20 @@ class STTimetable {
         lectureList.append(lecture)
         return STAddLectureState.success
     }
+    
+    func overlappingLectures(with: STLecture) -> [STLecture]? {
+        var overlapping: [STLecture] = []
+        for lecture in lectureList {
+            for class1 in lecture.classList {
+                for class2 in with.classList {
+                    if class1.time.isOverlappingWith(class2.time) {
+                        overlapping.append(lecture)
+                    }
+                }
+            }
+        }
+        return overlapping
+    }
 
     func indexOf(lecture: STLecture) -> Int {
         for (index, it) in lectureList.enumerated() {

--- a/SNUTT/SNUTT/STTimetable.swift
+++ b/SNUTT/SNUTT/STTimetable.swift
@@ -87,7 +87,7 @@ class STTimetable {
         lectureList.append(lecture)
         return STAddLectureState.success
     }
-    
+
     func overlappingLectures(with: STLecture) -> [STLecture]? {
         var overlapping: [STLecture] = []
         for lecture in lectureList {

--- a/SNUTT/SNUTT/STTimetableManager.swift
+++ b/SNUTT/SNUTT/STTimetableManager.swift
@@ -89,7 +89,7 @@ class STTimetableManager: NSObject {
     }
 
     func addLecture(_ lecture: STLecture, object: AnyObject?) {
-        STNetworking.addLecture(self.currentTimetable!, lectureId: lecture.id!, done: { newTimetable in
+        STNetworking.addLecture(currentTimetable!, lectureId: lecture.id!, done: { newTimetable in
             self.currentTimetable?.lectureList = newTimetable.lectureList
             STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: object)
         }, failure: {
@@ -161,12 +161,12 @@ class STTimetableManager: NSObject {
         }, failure: nil)
         STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: nil)
     }
-    
+
     func overwriteLecture(with lecture: STLecture, object: AnyObject?) {
-        guard let overlappingLectures = self.currentTimetable!.overlappingLectures(with: lecture) else { return }
-        
+        guard let overlappingLectures = currentTimetable!.overlappingLectures(with: lecture) else { return }
+
         for lec in overlappingLectures {
-            STNetworking.deleteLecture(self.currentTimetable!, lecture: lec) { newTimetable in
+            STNetworking.deleteLecture(currentTimetable!, lecture: lec) { newTimetable in
                 self.currentTimetable?.lectureList = newTimetable.lectureList
                 STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: nil)
             } failure: {
@@ -174,8 +174,8 @@ class STTimetableManager: NSObject {
                 STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: nil)
             }
         }
-        
-        STNetworking.addLecture(self.currentTimetable!, lectureId: lecture.id!, done: { newTimetable in
+
+        STNetworking.addLecture(currentTimetable!, lectureId: lecture.id!, done: { newTimetable in
             self.currentTimetable?.lectureList = newTimetable.lectureList
             STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: object)
         }, failure: {

--- a/SNUTT/SNUTT/STTimetableManager.swift
+++ b/SNUTT/SNUTT/STTimetableManager.swift
@@ -119,7 +119,7 @@ class STTimetableManager: NSObject {
             self.updateToOverwriteCustomLecture(oldLecture, newLecture: newLecture, index: index, done: done, failure: failure)
         })
     }
-    
+
     func overwriteLecture(lecture: STLecture, object: AnyObject?) {
         STNetworking.addLecture(currentTimetable!, lectureId: lecture.id!, isForced: true) { newTimetable in
             self.currentTimetable?.lectureList = newTimetable.lectureList
@@ -129,7 +129,7 @@ class STTimetableManager: NSObject {
             STEventCenter.sharedInstance.postNotification(event: .CurrentTimetableChanged, object: object)
         }
     }
-    
+
     func overwriteCustomLecture(lecture: STLecture, object: AnyObject?, done: (() -> Void)?, failure: (() -> Void)?) {
         STNetworking.addCustomLecture(currentTimetable!, lecture: lecture, isForced: true) { newTimetable in
             self.currentTimetable?.lectureList = newTimetable.lectureList
@@ -141,7 +141,7 @@ class STTimetableManager: NSObject {
             failure?()
         }
     }
-    
+
     func updateToOverwriteCustomLecture(_ oldLecture: STLecture, newLecture: STLecture, index: Int, done: @escaping () -> Void, failure: @escaping () -> Void) {
         STNetworking.updateLecture(currentTimetable!, oldLecture: oldLecture, newLecture: newLecture, isForced: true, done: { newTimetable in
             self.currentTimetable?.lectureList = newTimetable.lectureList


### PR DESCRIPTION
## 수정사항
- 강의(일반 강의 및 커스텀 포함)를 추가하고자 할 때와 커스텀 강의시간을 수정할 때, 시간표에 겹치는 시간대가 있는 경우 중복된 강의들을 모두 덮어쓸 수 있는 선택지를 제공합니다.
- 기존 코드에서 server의 응답에 따라 AlertView를 띄우는 로직이 `STSwiftyJSONRequest`에 위치하고 있어 `confirmAction`과 `cancelAction` parameter를 추가하는 방식으로 구현하였습니다. 이번 PR에서는 `cancelAction`이 사용될 일이 없지만 추후 확장성을 위하여 추가하였습니다.

https://user-images.githubusercontent.com/70614553/176494978-58ca9000-99b6-48cf-b6e9-b69415b488c9.mp4


