### PR TITLE
Add version headers for all requests [SNUTT-466]

### DIFF
--- a/SNUTT/SNUTT/STRouter.swift
+++ b/SNUTT/SNUTT/STRouter.swift
@@ -18,6 +18,19 @@ protocol STRouter: URLRequestConvertible {
 }
 
 extension STRouter {
+    private func setVersionHeaders(in request: NSMutableURLRequest) {
+        request.setValue(UIDevice.current.systemVersion, forHTTPHeaderField: "x-os-version")
+        request.setValue("ios", forHTTPHeaderField: "x-os-type")
+        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            request.setValue(appVersion, forHTTPHeaderField: "x-app-version")
+        }
+        #if DEBUG
+        request.setValue("debug", forHTTPHeaderField: "x-app-type")
+        #else
+        request.setValue("release", forHTTPHeaderField: "x-app-type")
+        #endif
+    }
+    
     var defaultURLRequest: NSMutableURLRequest {
         let URL = Foundation.URL(string: Self.baseURLString)!
         let mutableURLRequest = NSMutableURLRequest(url: URL.appendingPathComponent(path))
@@ -25,6 +38,7 @@ extension STRouter {
 
         let apikey = STDefaults[.apiKey]
         mutableURLRequest.setValue(apikey, forHTTPHeaderField: "x-access-apikey")
+        setVersionHeaders(in: mutableURLRequest)
         return mutableURLRequest
     }
 
@@ -33,6 +47,7 @@ extension STRouter {
         if let token = STDefaults[.token] {
             mutableURLRequest.setValue(token, forHTTPHeaderField: "x-access-token")
         }
+        setVersionHeaders(in: mutableURLRequest)
         return mutableURLRequest
     }
 

--- a/SNUTT/SNUTT/STRouter.swift
+++ b/SNUTT/SNUTT/STRouter.swift
@@ -25,12 +25,12 @@ extension STRouter {
             request.setValue(appVersion, forHTTPHeaderField: "x-app-version")
         }
         #if DEBUG
-        request.setValue("debug", forHTTPHeaderField: "x-app-type")
+            request.setValue("debug", forHTTPHeaderField: "x-app-type")
         #else
-        request.setValue("release", forHTTPHeaderField: "x-app-type")
+            request.setValue("release", forHTTPHeaderField: "x-app-type")
         #endif
     }
-    
+
     var defaultURLRequest: NSMutableURLRequest {
         let URL = Foundation.URL(string: Self.baseURLString)!
         let mutableURLRequest = NSMutableURLRequest(url: URL.appendingPathComponent(path))


### PR DESCRIPTION
# 수정 내용
- `STRouter`를 사용하는 모든 요청에 대해 `x-app-type`, `x-app-version`, `x-os-version`, `x-os-type` 헤더가 포함되게끔 설정했습니다.
- 패킷 모니터링 툴 사용해서 잘 작동하는 것 확인했습니다.

<img width="1020" alt="스크린샷 2022-07-04 오전 2 08 20" src="https://user-images.githubusercontent.com/33917774/177050125-157a9ab1-e5cd-4886-bd4f-307857d269d7.png">

