### PR TITLE
시간표 생성할 때 비어있거나 중복된 이름일 경우 alert가 두 번 뜨는 문제 [SNUTT-467]

### DIFF
--- a/SNUTT/SNUTT/MenuViewController.swift
+++ b/SNUTT/SNUTT/MenuViewController.swift
@@ -293,9 +293,7 @@ extension MenuViewController: SettingViewControllerDelegate {
 
             self.timetableList = timetableList
             self.reloadList()
-        }, failure: { errorTitle in
-            STAlertView.showAlert(title: errorTitle, message: "")
-        })
+        }) {_ in }
     }
 
     func deleteTimetable(_: SettingViewController, _ timetable: STTimetable) {

--- a/SNUTT/SNUTT/MenuViewController.swift
+++ b/SNUTT/SNUTT/MenuViewController.swift
@@ -293,7 +293,7 @@ extension MenuViewController: SettingViewControllerDelegate {
 
             self.timetableList = timetableList
             self.reloadList()
-        }) {_ in }
+        }) { _ in }
     }
 
     func deleteTimetable(_: SettingViewController, _ timetable: STTimetable) {

--- a/SNUTT/SNUTT/MenuViewController.swift
+++ b/SNUTT/SNUTT/MenuViewController.swift
@@ -232,14 +232,7 @@ extension MenuViewController: TimetablePickerViewControllerDelegate {
         STNetworking.createTimetable(title, courseBook: courseBook, done: { list in
             self.timetableList = list
             self.reloadList()
-        }, failure: {
-            // TODO: 응답에 따른 에러 핸들링
-            let alert = UIAlertController(title: "시간표 만들기 실패", message: "중복된 시간표 이름입니다", preferredStyle: .alert)
-            let ok = UIAlertAction(title: "확인", style: .cancel)
-            alert.addAction(ok)
-            self.present(alert, animated: true)
-
-        })
+        }) {}
     }
 }
 

--- a/SNUTT/SNUTT/STErrorCode.swift
+++ b/SNUTT/SNUTT/STErrorCode.swift
@@ -128,7 +128,7 @@ public enum STErrorCode: Int {
         case .NO_YEAR_OR_SEMESTER:
             return "올바른 년도와 학기를 정해주세요."
         case .NOT_ENOUGH_TO_CREATE_TIMETABLE:
-            return "올바른 년도, 학기, 이름을 정해주세요."
+            return "시간표의 이름이 비어있습니다."
         case .NO_LECTURE_INPUT:
             return "올바른 강좌를 넣어주세요."
         case .NO_LECTURE_ID:


### PR DESCRIPTION
## 수정사항
시간표를 생성할 때 이름이 비어있거나 다른 시간표의 이름과 중복되면 `STSwiftyJSONRequest`와 `MenuViewController`에서 한번씩 alert를 띄워서 두 개의 alert가 뜨는 문제가 있었습니다. 아래 영상에서는 비어있는 시간표 이름에 대해서만 녹화되어있는데 중복된 이름의 시간표에서도 동일한 문제가 발생합니다.

https://user-images.githubusercontent.com/70614553/177199193-6cbe89c8-b8df-4a35-9bc2-a37536abec06.mp4

