### PR TITLE
API 연동 및 에러 처리 [SNUTT-470]

### DIFF
--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -12,7 +12,8 @@
 		BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1D2B3928014527008F9134 /* Weekday.swift */; };
 		BE4B0EB628735005005FE164 /* MenuSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4B0EB528735005005FE164 /* MenuSheetViewModel.swift */; };
 		BE4B0EB828735052005FE164 /* MenuSheetSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4B0EB728735052005FE164 /* MenuSheetSetting.swift */; };
-		BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */; };
+		BE682BB6287C40AF009EBCB7 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BB5287C40AF009EBCB7 /* Theme.swift */; };
+		BE7E230127FF20EE004DC202 /* TimetableScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7E230027FF20EE004DC202 /* TimetableScene.swift */; };
 		BE7E230327FF3C38004DC202 /* NavBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7E230227FF3C38004DC202 /* NavBarButton.swift */; };
 		BE982FB8281D0B33005F71E6 /* TimetableBlocksLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */; };
 		BE982FBC281D5227005F71E6 /* TimePlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FBB281D5227005F71E6 /* TimePlace.swift */; };
@@ -28,7 +29,7 @@
 		BEDF506B27EB73EE00CDCC13 /* LectureListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF506A27EB73EE00CDCC13 /* LectureListCell.swift */; };
 		BEDF506D27EB740F00CDCC13 /* LectureList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF506C27EB740E00CDCC13 /* LectureList.swift */; };
 		BEDF506F27EB744A00CDCC13 /* LectureDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF506E27EB744A00CDCC13 /* LectureDetails.swift */; };
-		BEDF507327F427FA00CDCC13 /* MyLectureListScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507227F427FA00CDCC13 /* MyLectureListScene.swift */; };
+		BEDF507327F427FA00CDCC13 /* LectureListScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507227F427FA00CDCC13 /* LectureListScene.swift */; };
 		BEDF507527F4289B00CDCC13 /* Lecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507427F4289B00CDCC13 /* Lecture.swift */; };
 		BEDF507727F42D1100CDCC13 /* STFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507627F42D1100CDCC13 /* STFont.swift */; };
 		BEDF507927F42D7500CDCC13 /* STColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507827F42D7500CDCC13 /* STColor.swift */; };
@@ -93,7 +94,8 @@
 		BE682BB22879E24D009EBCB7 /* SNUTT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SNUTT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE682BB32879E24D009EBCB7 /* SNUTTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNUTTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE682BB42879E24D009EBCB7 /* SNUTTUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNUTTUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTimetableScene.swift; sourceTree = "<group>"; };
+		BE682BB5287C40AF009EBCB7 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		BE7E230027FF20EE004DC202 /* TimetableScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableScene.swift; sourceTree = "<group>"; };
 		BE7E230227FF3C38004DC202 /* NavBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavBarButton.swift; sourceTree = "<group>"; };
 		BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableBlocksLayer.swift; sourceTree = "<group>"; };
 		BE982FBB281D5227005F71E6 /* TimePlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePlace.swift; sourceTree = "<group>"; };
@@ -108,7 +110,7 @@
 		BEDF506A27EB73EE00CDCC13 /* LectureListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureListCell.swift; sourceTree = "<group>"; };
 		BEDF506C27EB740E00CDCC13 /* LectureList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureList.swift; sourceTree = "<group>"; };
 		BEDF506E27EB744A00CDCC13 /* LectureDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureDetails.swift; sourceTree = "<group>"; };
-		BEDF507227F427FA00CDCC13 /* MyLectureListScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLectureListScene.swift; sourceTree = "<group>"; };
+		BEDF507227F427FA00CDCC13 /* LectureListScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureListScene.swift; sourceTree = "<group>"; };
 		BEDF507427F4289B00CDCC13 /* Lecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lecture.swift; sourceTree = "<group>"; };
 		BEDF507627F42D1100CDCC13 /* STFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STFont.swift; sourceTree = "<group>"; };
 		BEDF507827F42D7500CDCC13 /* STColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STColor.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				DCD41A5F27E5CC7700CF380E /* Timetable.swift */,
 				BE982FBB281D5227005F71E6 /* TimePlace.swift */,
 				BEDF507427F4289B00CDCC13 /* Lecture.swift */,
+				BE682BB5287C40AF009EBCB7 /* Theme.swift */,
 				BE1D2B3928014527008F9134 /* Weekday.swift */,
 				DC2915A22866958100FE5F9A /* User.swift */,
 				DC2915A82866986600FE5F9A /* System.swift */,
@@ -302,8 +305,8 @@
 			isa = PBXGroup;
 			children = (
 				BEEBDFB9286B3A0C00DB5976 /* TabScene.swift */,
-				BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */,
-				BEDF507227F427FA00CDCC13 /* MyLectureListScene.swift */,
+				BE7E230027FF20EE004DC202 /* TimetableScene.swift */,
+				BEDF507227F427FA00CDCC13 /* LectureListScene.swift */,
 				DC29159A2865F95100FE5F9A /* SettingScene.swift */,
 				DC29159E28660F7800FE5F9A /* ReviewScene.swift */,
 				BECDB8992840CFAA00F62AC8 /* MenuSheetScene.swift */,
@@ -497,7 +500,7 @@
 				BEDF507727F42D1100CDCC13 /* STFont.swift in Sources */,
 				DC2915A128660FBB00FE5F9A /* ReviewViewModel.swift in Sources */,
 				BEDE34DC2879B40100525014 /* AppEnvironment.swift in Sources */,
-				BEDF507327F427FA00CDCC13 /* MyLectureListScene.swift in Sources */,
+				BEDF507327F427FA00CDCC13 /* LectureListScene.swift in Sources */,
 				BEEBDFBA286B3A0C00DB5976 /* TabScene.swift in Sources */,
 				DC29159D2865FA2800FE5F9A /* SettingViewModel.swift in Sources */,
 				DC1E0ED12877381F005632A3 /* Router.swift in Sources */,
@@ -534,8 +537,9 @@
 				BEEBDFB8286B38B600DB5976 /* SNUTTView.swift in Sources */,
 				BEDE34DA2879AA0B00525014 /* UserRepository.swift in Sources */,
 				DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */,
-				BE7E230127FF20EE004DC202 /* MyTimetableScene.swift in Sources */,
+				BE7E230127FF20EE004DC202 /* TimetableScene.swift in Sources */,
 				DCD41A7227E5CE1D00CF380E /* TimetableViewModel.swift in Sources */,
+				BE682BB6287C40AF009EBCB7 /* Theme.swift in Sources */,
 				DC2915A72866984000FE5F9A /* TimetableSetting.swift in Sources */,
 				BEDF507927F42D7500CDCC13 /* STColor.swift in Sources */,
 				BE4B0EB628735005005FE164 /* MenuSheetViewModel.swift in Sources */,

--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -90,6 +90,9 @@
 		BE1D2B3928014527008F9134 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		BE4B0EB528735005005FE164 /* MenuSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetViewModel.swift; sourceTree = "<group>"; };
 		BE4B0EB728735052005FE164 /* MenuSheetSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetSetting.swift; sourceTree = "<group>"; };
+		BE682BB22879E24D009EBCB7 /* SNUTT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SNUTT.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE682BB32879E24D009EBCB7 /* SNUTTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNUTTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE682BB42879E24D009EBCB7 /* SNUTTUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNUTTUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE7E230027FF20EE004DC202 /* MyTimetableScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTimetableScene.swift; sourceTree = "<group>"; };
 		BE7E230227FF3C38004DC202 /* NavBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavBarButton.swift; sourceTree = "<group>"; };
 		BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableBlocksLayer.swift; sourceTree = "<group>"; };
@@ -98,9 +101,6 @@
 		BE982FBF281D762F005F71E6 /* TimetableZStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableZStack.swift; sourceTree = "<group>"; };
 		BECDB897283B876300F62AC8 /* MenuSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheet.swift; sourceTree = "<group>"; };
 		BECDB8992840CFAA00F62AC8 /* MenuSheetScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetScene.swift; sourceTree = "<group>"; };
-		BEDE34CF2879A3FA00525014 /* SNUTT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = SNUTT.app; path = SNUTT.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		BEDE34D02879A3FA00525014 /* SNUTTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = SNUTTTests.xctest; path = SNUTTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BEDE34D12879A3FA00525014 /* SNUTTUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = SNUTTUITests.xctest; path = SNUTTUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEDE34D52879A7B800525014 /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
 		BEDE34D72879A9DC00525014 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
 		BEDE34D92879AA0B00525014 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
@@ -195,6 +195,9 @@
 				DC860F4727E5C87D0068C94B /* SNUTT */,
 				DC860F5827E5C87F0068C94B /* SNUTTTests */,
 				DC860F6227E5C87F0068C94B /* SNUTTUITests */,
+				BE682BB22879E24D009EBCB7 /* SNUTT.app */,
+				BE682BB32879E24D009EBCB7 /* SNUTTTests.xctest */,
+				BE682BB42879E24D009EBCB7 /* SNUTTUITests.xctest */,
 			);
 			sourceTree = "<group>";
 		};
@@ -374,7 +377,7 @@
 				BEDE34D32879A59B00525014 /* Alamofire */,
 			);
 			productName = SNUTT;
-			productReference = BEDE34CF2879A3FA00525014 /* SNUTT.app */;
+			productReference = BE682BB22879E24D009EBCB7 /* SNUTT.app */;
 			productType = "com.apple.product-type.application";
 		};
 		DC860F5427E5C87F0068C94B /* SNUTTTests */ = {
@@ -392,7 +395,7 @@
 			);
 			name = SNUTTTests;
 			productName = SNUTTTests;
-			productReference = BEDE34D02879A3FA00525014 /* SNUTTTests.xctest */;
+			productReference = BE682BB32879E24D009EBCB7 /* SNUTTTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		DC860F5E27E5C87F0068C94B /* SNUTTUITests */ = {
@@ -410,7 +413,7 @@
 			);
 			name = SNUTTUITests;
 			productName = SNUTTUITests;
-			productReference = BEDE34D12879A3FA00525014 /* SNUTTUITests.xctest */;
+			productReference = BE682BB42879E24D009EBCB7 /* SNUTTUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 /* End PBXNativeTarget section */
@@ -629,7 +632,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -684,7 +687,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -710,7 +713,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -740,7 +743,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SNUTT-2022/SNUTT/AppState/AppEnvironment.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppEnvironment.swift
@@ -40,7 +40,10 @@ extension AppEnvironment {
     }
 
     private static func configuredSession() -> Session {
-        return Session(interceptor: Interceptor(authStorage: Storage()), eventMonitors: [Logger()])
+        let storage = Storage()
+        storage.accessToken = "c7f446a2..."
+        storage.apiKey = "eyJ0eXAiO..."
+        return Session(interceptor: Interceptor(authStorage: storage), eventMonitors: [Logger()])
     }
 
     private static func configuredWebRepositories(session: Session) -> WebRepositories {

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -12,14 +12,13 @@ class AppState {
     var currentUser = User()
     var setting = Setting()
     var system = System()
-    var currentTimetable = Timetable(lectures: [])
 }
 
 #if DEBUG
     extension AppState {
         static var preview: AppState {
             let state = AppState()
-            state.currentTimetable = .preview
+            state.setting.timetableSetting.current = .preview
             return state
         }
     }

--- a/SNUTT-2022/SNUTT/Assets/STColor.swift
+++ b/SNUTT-2022/SNUTT/Assets/STColor.swift
@@ -6,5 +6,37 @@
 //
 
 import Foundation
+import SwiftUI
 
-struct STColor {}
+struct STColor {
+    static let cyan: Color = .init(hex: 0x1BD0C8)
+}
+
+extension Color {
+    init(hex: UInt64, alpha: Double = 1) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 08) & 0xFF) / 255,
+            blue: Double((hex >> 00) & 0xFF) / 255,
+            opacity: alpha
+        )
+    }
+    
+    init(hex:String, alpha: Double = 1) {
+        var str:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+
+        str = str.replacingOccurrences(of: "#", with: "")
+        str = str.replacingOccurrences(of: "0X", with: "")
+
+        if (str.count != 6) {
+            self.init(uiColor: .gray)
+            return
+        }
+
+        var rgbValue:UInt64 = 0
+        Scanner(string: str).scanHexInt64(&rgbValue)
+        
+        self.init(hex: rgbValue, alpha: alpha)
+    }
+}

--- a/SNUTT-2022/SNUTT/Assets/STColor.swift
+++ b/SNUTT-2022/SNUTT/Assets/STColor.swift
@@ -22,21 +22,21 @@ extension Color {
             opacity: alpha
         )
     }
-    
-    init(hex:String, alpha: Double = 1) {
-        var str:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+
+    init(hex: String, alpha: Double = 1) {
+        var str: String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
 
         str = str.replacingOccurrences(of: "#", with: "")
         str = str.replacingOccurrences(of: "0X", with: "")
 
-        if (str.count != 6) {
+        if str.count != 6 {
             self.init(uiColor: .gray)
             return
         }
 
-        var rgbValue:UInt64 = 0
+        var rgbValue: UInt64 = 0
         Scanner(string: str).scanHexInt64(&rgbValue)
-        
+
         self.init(hex: rgbValue, alpha: alpha)
     }
 }

--- a/SNUTT-2022/SNUTT/Models/Lecture.swift
+++ b/SNUTT-2022/SNUTT/Models/Lecture.swift
@@ -52,8 +52,7 @@ extension Lecture {
                            credit: Int.random(in: 0 ... 4),
                            department: departments.randomElement(),
                            academic_year: academic_years.randomElement(),
-                           colorIndex: 0
-            )
+                           colorIndex: 0)
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/Models/Lecture.swift
+++ b/SNUTT-2022/SNUTT/Models/Lecture.swift
@@ -16,7 +16,7 @@ struct Lecture: Identifiable {
     let credit: Int
     let department: String?
     let academic_year: String?
-    
+
     var isCustom: Bool {
         course_number == nil
     }
@@ -47,10 +47,9 @@ extension Lecture {
                            instructor: instructors.randomElement()!,
                            timePlaces: [.preview, .preview],
                            course_number: UUID().uuidString,
-                           credit: Int.random(in: 0...4),
+                           credit: Int.random(in: 0 ... 4),
                            department: departments.randomElement(),
-                           academic_year: academic_years.randomElement()
-            )
+                           academic_year: academic_years.randomElement())
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/Models/Lecture.swift
+++ b/SNUTT-2022/SNUTT/Models/Lecture.swift
@@ -12,6 +12,14 @@ struct Lecture: Identifiable {
     let title: String
     let instructor: String
     let timePlaces: [TimePlace]
+    let course_number: String?
+    let credit: Int
+    let department: String?
+    let academic_year: String?
+    
+    var isCustom: Bool {
+        course_number == nil
+    }
 }
 
 extension Lecture {
@@ -19,7 +27,11 @@ extension Lecture {
         id = dto._id
         title = dto.course_title
         instructor = dto.instructor
-        timePlaces = dto.class_time_json.map { .init(from: $0) }
+        timePlaces = dto.class_time_json.map { .init(from: $0, isCustom: dto.course_number == nil) }
+        course_number = dto.course_number
+        credit = dto.credit
+        department = dto.department
+        academic_year = dto.academic_year
     }
 }
 
@@ -28,7 +40,17 @@ extension Lecture {
         static var preview: Lecture {
             let instructors = ["염헌영", "엄현상", "김진수", "김형주", "이영기", "배영애", "유성호"]
             let titles = ["시스템프로그래밍", "양궁", "죽음의 과학적 이해", "북한학개론", "Operating System"]
-            return Lecture(id: UUID().uuidString, title: titles.randomElement()!, instructor: instructors.randomElement()!, timePlaces: [.preview, .preview])
+            let departments = ["경영학과", "컴퓨터공학과", "서양사학과", "디자인과"]
+            let academic_years = ["1학년", "2학년", "3학년", "학년"]
+            return Lecture(id: UUID().uuidString,
+                           title: titles.randomElement()!,
+                           instructor: instructors.randomElement()!,
+                           timePlaces: [.preview, .preview],
+                           course_number: UUID().uuidString,
+                           credit: Int.random(in: 0...4),
+                           department: departments.randomElement(),
+                           academic_year: academic_years.randomElement()
+            )
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/Models/Lecture.swift
+++ b/SNUTT-2022/SNUTT/Models/Lecture.swift
@@ -16,6 +16,7 @@ struct Lecture: Identifiable {
     let credit: Int
     let department: String?
     let academic_year: String?
+    let colorIndex: Int
 
     var isCustom: Bool {
         course_number == nil
@@ -32,6 +33,7 @@ extension Lecture {
         credit = dto.credit
         department = dto.department
         academic_year = dto.academic_year
+        colorIndex = dto.colorIndex
     }
 }
 
@@ -49,7 +51,9 @@ extension Lecture {
                            course_number: UUID().uuidString,
                            credit: Int.random(in: 0 ... 4),
                            department: departments.randomElement(),
-                           academic_year: academic_years.randomElement())
+                           academic_year: academic_years.randomElement(),
+                           colorIndex: 0
+            )
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/Models/Theme.swift
+++ b/SNUTT-2022/SNUTT/Models/Theme.swift
@@ -1,0 +1,70 @@
+//
+//  Theme.swift
+//  SNUTT
+//
+//  Created by 박신홍 on 2022/07/11.
+//
+
+enum Theme: Int, CaseIterable {
+    case SNUTT = 0
+    case FALL = 1
+    case MODERN = 2
+    case CHERRY_BLOSSOM = 3
+    case ICE = 4
+    case LAWN = 5
+
+    func getColorList() -> [String] {
+        switch self {
+        case .SNUTT:
+            return ["#ffffff", "#E54459", "#F58D3D", "#FAC42D", "#A6D930", "#2BC267", "#1BD0C8", "#1D99E8", "#4F48C4", "#AF56B3"]
+        case .FALL:
+            return ["#ffffff", "#B82E31", "#DB701C", "#EAA32A", "#C6C013", "#3A856E", "#19B2AC", "#3994CE", "#3F3A9C", "#924396"]
+        case .MODERN:
+            return ["#ffffff", "#F0652A", "#F5AD3E", "#998F36", "#89C291", "#266F55", "#13808F", "#366689", "#432920", "#D82F3D"]
+        case .CHERRY_BLOSSOM:
+            return ["#ffffff", "#FD79A8", "#FEC9DD", "#FEB0CC", "#FE93BF", "#E9B1D0", "#C67D97", "#BB8EA7", "#BDB4BF", "#E16597"]
+        case .ICE:
+            return ["#ffffff", "#AABDCF", "#C0E9E8", "#66B6CA", "#015F95", "#A8D0DB", "#66B6CA", "#62A9D1", "#20363D", "#6D8A96"]
+        case .LAWN:
+            return ["#ffffff", "#4FBEAA", "#9FC1A4", "#5A8173", "#84AEB1", "#266F55", "#D0E0C4", "#59886D", "#476060", "#3D7068"]
+        }
+    }
+    
+    func getColor(at colorIndex: Int) -> String {
+        return getColorList()[colorIndex]
+    }
+
+    func getImageName() -> String {
+        switch self {
+        case .SNUTT:
+            return "SNUTTTheme"
+        case .FALL:
+            return "FallTheme"
+        case .MODERN:
+            return "ModernTheme"
+        case .CHERRY_BLOSSOM:
+            return "CherryBlossomTheme"
+        case .ICE:
+            return "IceTheme"
+        case .LAWN:
+            return "LawnTheme"
+        }
+    }
+
+    func getName() -> String {
+        switch self {
+        case .SNUTT:
+            return "SNUTT"
+        case .FALL:
+            return "가을"
+        case .MODERN:
+            return "모던"
+        case .CHERRY_BLOSSOM:
+            return "벚꽃"
+        case .ICE:
+            return "얼음"
+        case .LAWN:
+            return "잔디"
+        }
+    }
+}

--- a/SNUTT-2022/SNUTT/Models/Theme.swift
+++ b/SNUTT-2022/SNUTT/Models/Theme.swift
@@ -29,7 +29,7 @@ enum Theme: Int, CaseIterable {
             return ["#ffffff", "#4FBEAA", "#9FC1A4", "#5A8173", "#84AEB1", "#266F55", "#D0E0C4", "#59886D", "#476060", "#3D7068"]
         }
     }
-    
+
     func getColor(at colorIndex: Int) -> String {
         return getColorList()[colorIndex]
     }

--- a/SNUTT-2022/SNUTT/Models/TimePlace.swift
+++ b/SNUTT-2022/SNUTT/Models/TimePlace.swift
@@ -8,24 +8,28 @@
 import Foundation
 
 struct TimePlace: Identifiable {
-    var id: String
+    let id: String
 
-    var day: Weekday
+    let day: Weekday
 
-    /// 단위: 교시
-    ///
-    /// 예를 들어, 7.5교시는 15시 30분으로 나타낸다.
-    var start: Double
+    
+    private let start: Double
 
     /// 단위: 시간
     ///
     /// - TODO: 서버에서 내려주는 시간은 0.5의 배수이다. 따라서 강의가 끝나는 시각을 정확하게 나타내기 위해서는 적절한 보정이 필요하다.
-    var len: Double
+    let len: Double
 
-    var place: String
-
+    let place: String
+    
+    let isCustom: Bool
+    
+    /// 단위: 교시
+    ///
+    /// 정규 강좌의 경우(`isCustom == false`), 7.5교시는 오후 15시 30분을 의미한다.
+    /// 그러나 커스텀 강좌의 경우(`isCustom == true`), 7.5교시는 오전 7시 30분을 의미한다.
     var startTime: Double {
-        start + 8
+        isCustom ? start : start + 8
     }
 
     var endTime: Double {
@@ -34,12 +38,13 @@ struct TimePlace: Identifiable {
 }
 
 extension TimePlace {
-    init(from dto: TimePlaceDto) {
+    init(from dto: TimePlaceDto, isCustom: Bool) {
         id = dto._id
         start = dto.start
         len = dto.len
         place = dto.place
         day = .init(rawValue: dto.day) ?? .mon
+        self.isCustom = isCustom
     }
 }
 
@@ -47,7 +52,12 @@ extension TimePlace {
     extension TimePlace {
         static var preview: Self {
             let place = "\(Int.random(in: 100 ... 999))-\(Int.random(in: 100 ... 999))"
-            return TimePlace(id: UUID().uuidString, day: .init(rawValue: Int.random(in: 0 ... 6))!, start: Double.random(in: 1 ... 8), len: Double.random(in: 0 ... 3), place: place)
+            return TimePlace(id: UUID().uuidString,
+                             day: .init(rawValue: Int.random(in: 0 ... 6))!,
+                             start: Double.random(in: 1 ... 8),
+                             len: Double.random(in: 0 ... 3),
+                             place: place,
+                             isCustom: Bool.random())
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/Models/TimePlace.swift
+++ b/SNUTT-2022/SNUTT/Models/TimePlace.swift
@@ -12,7 +12,6 @@ struct TimePlace: Identifiable {
 
     let day: Weekday
 
-    
     private let start: Double
 
     /// 단위: 시간
@@ -21,9 +20,9 @@ struct TimePlace: Identifiable {
     let len: Double
 
     let place: String
-    
+
     let isCustom: Bool
-    
+
     /// 단위: 교시
     ///
     /// 정규 강좌의 경우(`isCustom == false`), 7.5교시는 오후 15시 30분을 의미한다.

--- a/SNUTT-2022/SNUTT/Models/Timetable.swift
+++ b/SNUTT-2022/SNUTT/Models/Timetable.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-class Timetable: ObservableObject {
-    @Published var lectures: [Lecture]
+struct Timetable {
+    var lectures: [Lecture]
 
     init(lectures: [Lecture]) {
         self.lectures = lectures

--- a/SNUTT-2022/SNUTT/Models/Timetable.swift
+++ b/SNUTT-2022/SNUTT/Models/Timetable.swift
@@ -23,8 +23,7 @@ extension Timetable {
     extension Timetable {
         static var preview: Timetable {
             return .init(lectures: [.preview, .preview, .preview],
-                         theme: .SNUTT
-            )
+                         theme: .SNUTT)
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/Models/Timetable.swift
+++ b/SNUTT-2022/SNUTT/Models/Timetable.swift
@@ -8,21 +8,23 @@
 import SwiftUI
 
 struct Timetable {
-    var lectures: [Lecture]
+    let lectures: [Lecture]
+    let theme: Theme
+}
 
-    init(lectures: [Lecture]) {
-        self.lectures = lectures
-    }
-
+extension Timetable {
     init(from dto: TimetableDto) {
         lectures = dto.lecture_list.map { .init(from: $0) }
+        theme = .init(rawValue: dto.theme) ?? .SNUTT
     }
 }
 
 #if DEBUG
     extension Timetable {
         static var preview: Timetable {
-            return .init(lectures: [.preview, .preview, .preview])
+            return .init(lectures: [.preview, .preview, .preview],
+                         theme: .SNUTT
+            )
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/Models/TimetableSetting.swift
+++ b/SNUTT-2022/SNUTT/Models/TimetableSetting.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 class TimetableSetting: ObservableObject {
+    @Published var current: Timetable?
     let minHour: Int = 8
     let maxHour: Int = 19
 
-    let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri]
+    let visibleWeeks: [Weekday] = [.mon, .tue, .wed, .thu, .fri, .sat]
 
     var hourCount: Int {
         maxHour - minHour + 1

--- a/SNUTT-2022/SNUTT/Models/Weekday.swift
+++ b/SNUTT-2022/SNUTT/Models/Weekday.swift
@@ -8,19 +8,23 @@
 import Foundation
 
 enum Weekday: Int, Identifiable, Codable {
-    case sun, mon, tue, wed, thu, fri, sat
-
+    case mon, tue, wed, thu, fri, sat, sun
+    
     var id: RawValue { rawValue }
+    
+    var sundayIndexedId: Int {
+        (id + 1) % 7
+    }
 
     public var symbol: String {
-        Calendar.current.weekdaySymbols[id]
+        Calendar.current.weekdaySymbols[sundayIndexedId]
     }
 
     public var shortSymbol: String {
-        Calendar.current.shortWeekdaySymbols[id]
+        Calendar.current.shortWeekdaySymbols[sundayIndexedId]
     }
 
     public var veryShortSymbol: String {
-        Calendar.current.veryShortWeekdaySymbols[id]
+        Calendar.current.veryShortWeekdaySymbols[sundayIndexedId]
     }
 }

--- a/SNUTT-2022/SNUTT/Models/Weekday.swift
+++ b/SNUTT-2022/SNUTT/Models/Weekday.swift
@@ -9,9 +9,9 @@ import Foundation
 
 enum Weekday: Int, Identifiable, Codable {
     case mon, tue, wed, thu, fri, sat, sun
-    
+
     var id: RawValue { rawValue }
-    
+
     var sundayIndexedId: Int {
         (id + 1) % 7
     }

--- a/SNUTT-2022/SNUTT/Repositories/Dto/TimetableDto.swift
+++ b/SNUTT-2022/SNUTT/Repositories/Dto/TimetableDto.swift
@@ -20,20 +20,20 @@ struct TimetableDto: Codable {
 
 struct LectureDto: Codable {
     let _id: String
-    let classification: String
-    let department: String
-    let academic_year: String
+    let classification: String?
+    let department: String?
+    let academic_year: String?
     let course_title: String
     let credit: Int
-    let class_time: String
+    let class_time: String?
     let class_time_json: [TimePlaceDto]
     let class_time_mask: [Int]
     let instructor: String
-    let quota: Int
+    let quota: Int?
     let remark: String
-    let category: String
-    let course_number: String
-    let lecture_number: String
+    let category: String?
+    let course_number: String?
+    let lecture_number: String?
     let created_at: String
     let updated_at: String
     let color: [String: String]

--- a/SNUTT-2022/SNUTT/Services/TimetableService.swift
+++ b/SNUTT-2022/SNUTT/Services/TimetableService.swift
@@ -7,16 +7,33 @@
 
 import Foundation
 
-protocol TimetableServiceProtocol {}
+protocol TimetableServiceProtocol {
+    func fetchRecentTimetable() async throws
+}
 
 struct TimetableService: TimetableServiceProtocol {
-    let appState: AppState
-    let webRepositories: AppEnvironment.WebRepositories
-
+    var appState: AppState
+    var webRepositories: AppEnvironment.WebRepositories
+    
+    var timetableRepository: TimetableRepositoryProtocol {
+        webRepositories.timetableRepository
+    }
+    
     init(appState: AppState, webRepositories: AppEnvironment.WebRepositories) {
         self.appState = appState
         self.webRepositories = webRepositories
     }
+    
+    func fetchRecentTimetable() async throws {
+        let dto = try await timetableRepository.fetchRecentTimetable()
+        let timetable = Timetable(from: dto)
+        DispatchQueue.main.async {
+            appState.setting.timetableSetting.current = timetable
+        }
+    }
 }
 
-struct FakeTimetableService: TimetableServiceProtocol {}
+struct FakeTimetableService: TimetableServiceProtocol {
+    func fetchRecentTimetable() {
+    }
+}

--- a/SNUTT-2022/SNUTT/Services/TimetableService.swift
+++ b/SNUTT-2022/SNUTT/Services/TimetableService.swift
@@ -14,16 +14,16 @@ protocol TimetableServiceProtocol {
 struct TimetableService: TimetableServiceProtocol {
     var appState: AppState
     var webRepositories: AppEnvironment.WebRepositories
-    
+
     var timetableRepository: TimetableRepositoryProtocol {
         webRepositories.timetableRepository
     }
-    
+
     init(appState: AppState, webRepositories: AppEnvironment.WebRepositories) {
         self.appState = appState
         self.webRepositories = webRepositories
     }
-    
+
     func fetchRecentTimetable() async throws {
         let dto = try await timetableRepository.fetchRecentTimetable()
         let timetable = Timetable(from: dto)
@@ -34,6 +34,5 @@ struct TimetableService: TimetableServiceProtocol {
 }
 
 struct FakeTimetableService: TimetableServiceProtocol {
-    func fetchRecentTimetable() {
-    }
+    func fetchRecentTimetable() {}
 }

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -18,7 +18,7 @@ class MyLectureListViewModel {
     private var appState: AppState {
         container.appState
     }
-    
+
     var currentTimetable: Timetable? {
         appState.setting.timetableSetting.current
     }

--- a/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MyLectureListViewModel.swift
@@ -18,12 +18,8 @@ class MyLectureListViewModel {
     private var appState: AppState {
         container.appState
     }
-
-    var currentTimetable: Timetable {
-        appState.currentTimetable
-    }
-
-    func updateTimetable(timeTable: Timetable) {
-        appState.currentTimetable = timeTable
+    
+    var currentTimetable: Timetable? {
+        appState.setting.timetableSetting.current
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -18,12 +18,4 @@ class ReviewViewModel {
     private var appState: AppState {
         container.appState
     }
-
-    var currentTimetable: Timetable {
-        appState.currentTimetable
-    }
-
-    func updateTimetable(timeTable _: Timetable) {
-        appState.currentTimetable.lectures = []
-    }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -19,7 +19,7 @@ class TimetableViewModel: ObservableObject {
     private var appState: AppState {
         container.appState
     }
-    
+
     private var timetableService: TimetableServiceProtocol {
         container.services.timetableService
     }
@@ -35,7 +35,7 @@ class TimetableViewModel: ObservableObject {
     func toggleMenuSheet() {
         appState.setting.menuSheetSetting.isOpen.toggle()
     }
-    
+
     func fetchRecentTimetable() async {
         if currentTimetable != nil {
             return

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 import UIKit
 
-class TimetableViewModel {
+class TimetableViewModel: ObservableObject {
+    @Published var showAlert: Bool = false
     var container: DIContainer
 
     init(container: DIContainer) {
@@ -18,21 +19,34 @@ class TimetableViewModel {
     private var appState: AppState {
         container.appState
     }
+    
+    private var timetableService: TimetableServiceProtocol {
+        container.services.timetableService
+    }
 
-    var currentTimetable: Timetable {
-        appState.currentTimetable
+    var currentTimetable: Timetable? {
+        appState.setting.timetableSetting.current
     }
 
     var timetableSetting: TimetableSetting {
         appState.setting.timetableSetting
     }
 
-    func updateTimetable(timeTable: Timetable) {
-        appState.currentTimetable = timeTable
-    }
-
     func toggleMenuSheet() {
         appState.setting.menuSheetSetting.isOpen.toggle()
+    }
+    
+    func fetchRecentTimetable() async {
+        if currentTimetable != nil {
+            return
+        }
+        do {
+            try await timetableService.fetchRecentTimetable()
+        } catch {
+            DispatchQueue.main.async {
+                self.showAlert = true
+            }
+        }
     }
 
     struct TimetablePainter {

--- a/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
@@ -27,12 +27,16 @@ struct LectureListCell: View {
                 Text(lecture.title)
                     .font(STFont.subheading)
                 Spacer()
-                Text("정희숙 / 3학점")
+                Text("\(lecture.instructor) / \(lecture.credit)학점")
                     .font(STFont.details)
             }
 
             // details
-            detailRow(imageName: "tag.black", text: "디자인학부(디자인전공), 3학년")
+            if lecture.isCustom {
+                detailRow(imageName: "tag.black", text: "(없음)")
+            } else {
+                detailRow(imageName: "tag.black", text: "\(lecture.department ?? "-"), \(lecture.academic_year ?? "-")")
+            }
             detailRow(imageName: "clock.black", text: "목2")
             detailRow(imageName: "map.black", text: "049-215")
         }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/LectureBlocks.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/LectureBlocks.swift
@@ -18,7 +18,8 @@ struct LectureBlocks: View {
             ForEach(lecture.timePlaces) { timePlace in
                 if let offsetPoint = Painter.getOffset(of: timePlace,
                                                        in: reader.size,
-                                                       timetableSetting: timetableSetting) {
+                                                       timetableSetting: timetableSetting)
+                {
                     TimetableBlock(lecture: lecture, timePlace: timePlace, theme: timetableSetting.current?.theme ?? .SNUTT)
                         .frame(width: Painter.getWeekWidth(in: reader.size, weekCount: timetableSetting.weekCount), height: Painter.getHeight(of: timePlace, in: reader.size, hourCount: timetableSetting.hourCount), alignment: .center)
                         .offset(x: offsetPoint.x, y: offsetPoint.y)

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/LectureBlocks.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/LectureBlocks.swift
@@ -16,8 +16,10 @@ struct LectureBlocks: View {
     var body: some View {
         GeometryReader { reader in
             ForEach(lecture.timePlaces) { timePlace in
-                if let offsetPoint = Painter.getOffset(of: timePlace, in: reader.size, timetableSetting: timetableSetting) {
-                    TimetableBlock(lecture: lecture, timePlace: timePlace)
+                if let offsetPoint = Painter.getOffset(of: timePlace,
+                                                       in: reader.size,
+                                                       timetableSetting: timetableSetting) {
+                    TimetableBlock(lecture: lecture, timePlace: timePlace, theme: timetableSetting.current?.theme ?? .SNUTT)
                         .frame(width: Painter.getWeekWidth(in: reader.size, weekCount: timetableSetting.weekCount), height: Painter.getHeight(of: timePlace, in: reader.size, hourCount: timetableSetting.hourCount), alignment: .center)
                         .offset(x: offsetPoint.x, y: offsetPoint.y)
                 }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlock.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlock.swift
@@ -10,11 +10,12 @@ import SwiftUI
 struct TimetableBlock: View {
     let lecture: Lecture
     let timePlace: TimePlace
+    let theme: Theme
 
     var body: some View {
         ZStack {
             Rectangle()
-                .fill(.orange)
+                .fill(Color(hex: theme.getColor(at: lecture.colorIndex)))
                 .border(Color.black.opacity(0.1), width: 0.5)
             VStack {
                 Group {
@@ -32,7 +33,7 @@ struct TimetableBlock: View {
 struct TimetableBlock_Previews: PreviewProvider {
     static var previews: some View {
         let lecture: Lecture = .preview
-        TimetableBlock(lecture: lecture, timePlace: lecture.timePlaces[0])
+        TimetableBlock(lecture: lecture, timePlace: lecture.timePlaces[0], theme: .SNUTT)
             .frame(width: 70, height: 100, alignment: .center)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlocksLayer.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct TimetableBlocksLayer: View {
-    @EnvironmentObject var currentTimetable: Timetable
+    @EnvironmentObject var timetableSetting: TimetableSetting
 
     var body: some View {
-        ForEach(currentTimetable.lectures) { lecture in
+        ForEach(timetableSetting.current?.lectures ?? []) { lecture in
             LectureBlocks(lecture: lecture)
         }
 
@@ -24,7 +24,6 @@ struct TimetableBlocks_Previews: PreviewProvider {
         ZStack {
             let viewModel = TimetableViewModel(container: .preview)
             TimetableBlocksLayer()
-                .environmentObject(viewModel.currentTimetable)
                 .environmentObject(viewModel.timetableSetting)
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableZStack.swift
@@ -22,7 +22,6 @@ struct TimetableStack_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = TimetableViewModel(container: .preview)
         TimetableZStack()
-            .environmentObject(viewModel.currentTimetable)
             .environmentObject(viewModel.timetableSetting)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -15,10 +15,10 @@ struct SNUTTView: View {
         ZStack {
             TabView(selection: $selectedTab) {
                 TabScene(tabType: .timetable) {
-                    MyTimetableScene(viewModel: .init(container: container))
+                    TimetableScene(viewModel: .init(container: container))
                 }
                 TabScene(tabType: .search) {
-                    MyLectureListScene(viewModel: .init(container: container))
+                    LectureListScene(viewModel: .init(container: container))
                 }
                 TabScene(tabType: .review) {
                     ReviewScene(viewModel: .init(container: container))

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureListScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureListScene.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct MyLectureListScene: View {
+struct LectureListScene: View {
     let viewModel: MyLectureListViewModel
 
     var body: some View {
@@ -29,7 +29,7 @@ struct MyTimetableListScene_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             TabView {
-                MyLectureListScene(viewModel: .init(container: .preview))
+                LectureListScene(viewModel: .init(container: .preview))
             }
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyLectureListScene.swift
@@ -11,7 +11,7 @@ struct MyLectureListScene: View {
     let viewModel: MyLectureListViewModel
 
     var body: some View {
-        LectureList(lectures: viewModel.currentTimetable.lectures)
+        LectureList(lectures: viewModel.currentTimetable?.lectures ?? [])
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct MyTimetableScene: View {
     @State private var pushToListScene = false
     @StateObject var viewModel: TimetableViewModel
-    
+
     var body: some View {
         TimetableZStack()
             .environmentObject(viewModel.timetableSetting)
-        // navigate programmatically, because NavigationLink inside toolbar doesn't work
+            // navigate programmatically, because NavigationLink inside toolbar doesn't work
             .background(
                 NavigationLink(destination: MyLectureListScene(viewModel: .init(container: viewModel.container)), isActive: $pushToListScene) {
                     EmptyView()
@@ -27,22 +27,22 @@ struct MyTimetableScene: View {
                         NavBarButton(imageName: "nav.menu") {
                             viewModel.toggleMenuSheet()
                         }
-                        
+
                         Text("나의 시간표").font(STFont.title)
                         Text("(18 학점)")
                             .font(STFont.details)
                             .foregroundColor(Color(UIColor.secondaryLabel))
-                        
+
                         Spacer()
-                        
+
                         NavBarButton(imageName: "nav.list") {
                             pushToListScene = true
                         }
-                        
+
                         NavBarButton(imageName: "nav.share") {
                             print("share tapped")
                         }
-                        
+
                         NavBarButton(imageName: "nav.alarm.off") {
                             print("alarm tapped")
                         }
@@ -53,9 +53,9 @@ struct MyTimetableScene: View {
                 await viewModel.fetchRecentTimetable()
             }
             .alert(isPresented: $viewModel.showAlert) {
-                return Alert(title: Text("API 에러"), message: Text("API 에러가 발생했습니다. 이 알러트는 테스트용입니다. 나중에 바꿔주세요."), dismissButton: .default(Text("취소")))
+                Alert(title: Text("API 에러"), message: Text("API 에러가 발생했습니다. 이 알러트는 테스트용입니다. 나중에 바꿔주세요."), dismissButton: .default(Text("취소")))
             }
-        
+
         let _ = debugChanges()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MyTimetableScene.swift
@@ -9,13 +9,12 @@ import SwiftUI
 
 struct MyTimetableScene: View {
     @State private var pushToListScene = false
-    let viewModel: TimetableViewModel
-
+    @StateObject var viewModel: TimetableViewModel
+    
     var body: some View {
         TimetableZStack()
-            .environmentObject(viewModel.currentTimetable)
             .environmentObject(viewModel.timetableSetting)
-            // navigate programmatically, because NavigationLink inside toolbar doesn't work
+        // navigate programmatically, because NavigationLink inside toolbar doesn't work
             .background(
                 NavigationLink(destination: MyLectureListScene(viewModel: .init(container: viewModel.container)), isActive: $pushToListScene) {
                     EmptyView()
@@ -28,29 +27,35 @@ struct MyTimetableScene: View {
                         NavBarButton(imageName: "nav.menu") {
                             viewModel.toggleMenuSheet()
                         }
-
+                        
                         Text("나의 시간표").font(STFont.title)
                         Text("(18 학점)")
                             .font(STFont.details)
                             .foregroundColor(Color(UIColor.secondaryLabel))
-
+                        
                         Spacer()
-
+                        
                         NavBarButton(imageName: "nav.list") {
                             pushToListScene = true
                         }
-
+                        
                         NavBarButton(imageName: "nav.share") {
                             print("share tapped")
                         }
-
+                        
                         NavBarButton(imageName: "nav.alarm.off") {
                             print("alarm tapped")
                         }
                     }
                 }
             }
-
+            .task {
+                await viewModel.fetchRecentTimetable()
+            }
+            .alert(isPresented: $viewModel.showAlert) {
+                return Alert(title: Text("API 에러"), message: Text("API 에러가 발생했습니다. 이 알러트는 테스트용입니다. 나중에 바꿔주세요."), dismissButton: .default(Text("취소")))
+            }
+        
         let _ = debugChanges()
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -13,7 +13,7 @@ struct ReviewScene: View {
 
     var body: some View {
         Button {
-            viewModel.updateTimetable(timeTable: Timetable(lectures: []))
+//            viewModel.updateTimetable(timeTable: Timetable(lectures: []))
         } label: {
             Text("Change current timetable")
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct MyTimetableScene: View {
+struct TimetableScene: View {
     @State private var pushToListScene = false
     @StateObject var viewModel: TimetableViewModel
 
@@ -16,7 +16,7 @@ struct MyTimetableScene: View {
             .environmentObject(viewModel.timetableSetting)
             // navigate programmatically, because NavigationLink inside toolbar doesn't work
             .background(
-                NavigationLink(destination: MyLectureListScene(viewModel: .init(container: viewModel.container)), isActive: $pushToListScene) {
+                NavigationLink(destination: LectureListScene(viewModel: .init(container: viewModel.container)), isActive: $pushToListScene) {
                     EmptyView()
                 }
             )
@@ -63,7 +63,7 @@ struct MyTimetableScene: View {
 struct MyTimetableScene_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            MyTimetableScene(viewModel: .init(container: .preview))
+            TimetableScene(viewModel: .init(container: .preview))
         }
     }
 }


### PR DESCRIPTION
# 주요 변경사항

- AppState의 `currentTimetable`을 `TimetableSetting`의 하위로 옮겼습니다. 스프린트에서는 `@Published var currentTimetable: Timetable`과 같이 선언한 뒤에 AppState를 `ObservableObject`를 만드는 쪽으로 얘기했었지만, 그렇게 하면 View에서 AppState를 직접 구독해야 합니다. `TimetableSetting`으로 옮기는 것이 의미상으로도, 통일성의 측면에서도 적절하다고 판단했고요.
    - currentTimetable은 Optional로 변경했습니다. 그렇게 하지 않으면 초기에 currentTimetable을 얻어올 때까지 `init()` 태스크가 block되므로 앱 시작 속도에 악영향이 있을 것이라고 생각했습니다. 
- Service의 역할을, `Repository를 통해 API 호출 - DTO를 Model로 변환 - AppState를 적절히 변경`에 한정했으며, 나머지 로직은 뷰모델에서 수행하도록 구현했습니다.
- Repository에서 API 호출하는 동안에 발생하는 에러는, 계속해서 `throw`하다가 ViewModel에서 `catch`하여 핸들링하도록 구현했습니다.
- 구체적인 에러 핸들링 로직은 #88 에서 구현했습니다.
- `async` 함수는 View의 `.task()` modifier에서 호출하도록 구현했습니다.