### PR TITLE
강의 삭제 전 Alert 띄우기

### DIFF
--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -136,14 +136,12 @@ struct LectureDetailScene: View {
                         }
                     }
                     .padding()
-
+                    
                     if !editMode.isEditing {
                         DetailButton(text: "강의계획서") {
-                            print("tap")
                         }
-
+                        
                         DetailButton(text: "강의평") {
-                            print("tap")
                         }
                     }
 
@@ -330,7 +328,6 @@ struct EditableTimeField: View {
 
     var body: some View {
         Button {
-            print("hi")
         } label: {
             timeTextLabel(from: timePlace)
                 .font(.system(size: 16, weight: .regular))

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct LectureDetailScene: View {
     @ObservedObject var viewModel: ViewModel
     @State var lecture: Lecture
-    
+
     @State private var editMode: EditMode = .inactive
     @State private var tempLecture: Lecture = .preview
     @State private var isDeleteAlertPresented = false
@@ -136,12 +136,12 @@ struct LectureDetailScene: View {
                         }
                     }
                     .padding()
-                    
+
                     if !editMode.isEditing {
                         DetailButton(text: "강의계획서") {
                             print("tap")
                         }
-                        
+
                         DetailButton(text: "강의평") {
                             print("tap")
                         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -11,8 +11,10 @@ import SwiftUI
 struct LectureDetailScene: View {
     @ObservedObject var viewModel: ViewModel
     @State var lecture: Lecture
+    
     @State private var editMode: EditMode = .inactive
     @State private var tempLecture: Lecture = .preview
+    @State private var isDeleteAlertPresented = false
 
     // for modal presentation
     var isPresentedModally: Bool = false
@@ -147,9 +149,14 @@ struct LectureDetailScene: View {
 
                     if !isPresentedModally {
                         DetailButton(text: "삭제", role: .destructive) {
-                            // TODO: check alert
-                            Task {
-                                await viewModel.deleteLecture(lecture: lecture)
+                            isDeleteAlertPresented = true
+                        }
+                        .alert("강의를 삭제하시겠습니까?", isPresented: $isDeleteAlertPresented) {
+                            Button("취소", role: .cancel, action: {})
+                            Button("삭제", role: .destructive) {
+                                Task {
+                                    await viewModel.deleteLecture(lecture: lecture)
+                                }
                             }
                         }
                     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -134,13 +134,15 @@ struct LectureDetailScene: View {
                         }
                     }
                     .padding()
-
-                    DetailButton(text: "강의계획서") {
-                        print("tap")
-                    }
-
-                    DetailButton(text: "강의평") {
-                        print("tap")
+                    
+                    if !editMode.isEditing {
+                        DetailButton(text: "강의계획서") {
+                            print("tap")
+                        }
+                        
+                        DetailButton(text: "강의평") {
+                            print("tap")
+                        }
                     }
 
                     if !isPresentedModally {
@@ -154,6 +156,7 @@ struct LectureDetailScene: View {
                 }
                 .background(STColor.groupForeground)
             }
+            .animation(.customSpring, value: editMode.isEditing)
             .padding(.vertical, 20)
         }
         .background(STColor.groupBackground)


### PR DESCRIPTION
- 강의 삭제 전 Alert를 띄우고,
- 강의 편집 모드에서는 `강의평`, `강의계획서`와 같은 버튼들이 보이지 않도록 했습니다.

<img width="564" alt="스크린샷 2022-09-14 오후 10 53 54" src="https://user-images.githubusercontent.com/33917774/190173689-78cf6d16-28b9-4198-af3c-8f239c0ac5f3.png">
