### PR TITLE
AuthService 구현, 토큰 관리 방식 변경

### DIFF
--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -45,12 +45,12 @@
 		B8F40EB728980E7A0021A2A9 /* AccountSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F40EB628980E7A0021A2A9 /* AccountSettingViewModel.swift */; };
 		B8F570A6289E1221005C199F /* UserDefaults+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F570A5289E1221005C199F /* UserDefaults+ext.swift */; };
 		B8F570A7289E1233005C199F /* UserDefaults+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F570A5289E1221005C199F /* UserDefaults+ext.swift */; };
+		BE060BD728DF43AC00A2F1B9 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE060BD628DF43AC00A2F1B9 /* AuthService.swift */; };
+		BE060BD928DF4C1E00A2F1B9 /* LoginScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE060BD828DF4C1E00A2F1B9 /* LoginScene.swift */; };
+		BE060C1228DF573900A2F1B9 /* UserDefaults+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F570A5289E1221005C199F /* UserDefaults+ext.swift */; };
 		BE0743DD28DC08CE00999F86 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0743DC28DC08CE00999F86 /* TestUtils.swift */; };
 		BE0743E128DC0A6500999F86 /* STColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507827F42D7500CDCC13 /* STColor.swift */; };
 		BE0743E228DC0A6700999F86 /* STFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507627F42D1100CDCC13 /* STFont.swift */; };
-		BE0743E328DC0ABC00999F86 /* ErrorDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BEE288722A5009EBCB7 /* ErrorDto.swift */; };
-		BE0743E528DC0AC900999F86 /* CourseBookDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE77D0A328AEAD4D0067A9D8 /* CourseBookDto.swift */; };
-		BE0743E628DC0AD100999F86 /* NetworkConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E51E6528B5EC500065248E /* NetworkConfiguration.swift */; };
 		BE13C5B528AE4CBA0081D0AB /* UserDefaultsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13C5B428AE4CBA0081D0AB /* UserDefaultsRepository.swift */; };
 		BE13C5B628AE636D0081D0AB /* UserDefaultsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13C5B428AE4CBA0081D0AB /* UserDefaultsRepository.swift */; };
 		BE1B610C289D7C2500401361 /* GlobalUIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1B610B289D7C2500401361 /* GlobalUIService.swift */; };
@@ -85,11 +85,6 @@
 		BE682BD3288676FA009EBCB7 /* LectureRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BD2288676FA009EBCB7 /* LectureRepositoryTests.swift */; };
 		BE682BD928870718009EBCB7 /* LectureRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BD828870718009EBCB7 /* LectureRepository.swift */; };
 		BE682BDB28870872009EBCB7 /* LectureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BDA28870872009EBCB7 /* LectureService.swift */; };
-		BE682BDC28870C4C009EBCB7 /* TimetableDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9C2CAA287805D3009EC3BC /* TimetableDto.swift */; };
-		BE682BDE28870C5B009EBCB7 /* Lecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507427F4289B00CDCC13 /* Lecture.swift */; };
-		BE682BDF28870C69009EBCB7 /* Timetable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD41A5F27E5CC7700CF380E /* Timetable.swift */; };
-		BE682BE028870C6E009EBCB7 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BB5287C40AF009EBCB7 /* Theme.swift */; };
-		BE682BE128870C71009EBCB7 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1D2B3928014527008F9134 /* Weekday.swift */; };
 		BE682BE328870EBD009EBCB7 /* LectureDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BE228870EBD009EBCB7 /* LectureDetailViewModel.swift */; };
 		BE682BEF288722A5009EBCB7 /* ErrorDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BEE288722A5009EBCB7 /* ErrorDto.swift */; };
 		BE682BF128872315009EBCB7 /* STError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BF028872315009EBCB7 /* STError.swift */; };
@@ -101,9 +96,6 @@
 		BE682C03288817C8009EBCB7 /* SearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682C02288817C8009EBCB7 /* SearchRepository.swift */; };
 		BE682C0528881852009EBCB7 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682C0428881852009EBCB7 /* SearchService.swift */; };
 		BE779B0428E313B7009960EB /* SearchLectureCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE779B0328E313B7009960EB /* SearchLectureCell.swift */; };
-		BE779B0528E32882009960EB /* Quarter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BFE2888056C009EBCB7 /* Quarter.swift */; };
-		BE779B0628E32888009960EB /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB3B6A428CDE1FD00E56062 /* TimeUtils.swift */; };
-		BE779B0728E328A7009960EB /* TimePlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FBB281D5227005F71E6 /* TimePlace.swift */; };
 		BE77D09E28AEAA5A0067A9D8 /* CourseBookRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE77D09D28AEAA5A0067A9D8 /* CourseBookRouter.swift */; };
 		BE77D0A028AEAB920067A9D8 /* CourseBookRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE77D09F28AEAB920067A9D8 /* CourseBookRepository.swift */; };
 		BE77D0A428AEAD4D0067A9D8 /* CourseBookDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE77D0A328AEAD4D0067A9D8 /* CourseBookDto.swift */; };
@@ -135,13 +127,8 @@
 		BE9413DB28C3B33300171060 /* SearchTips.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413DA28C3B33300171060 /* SearchTips.swift */; };
 		BE9413DD28C3B68F00171060 /* SearchTagsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413DC28C3B68F00171060 /* SearchTagsScrollView.swift */; };
 		BE9413DF28C3BDF600171060 /* SearchLectureList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413DE28C3BDF600171060 /* SearchLectureList.swift */; };
-		BE9413E128CCD04900171060 /* LectureTimeSheetScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413E028CCD04900171060 /* LectureTimeSheetScene.swift */; };
-		BE95D1F128DC22DB009C0C0B /* STError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE682BF028872315009EBCB7 /* STError.swift */; };
 		BE95D1F728DF2F44009C0C0B /* AuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE95D1F628DF2F44009C0C0B /* AuthRepository.swift */; };
 		BE95D1F928DF32EC009C0C0B /* AuthRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE95D1F828DF32EC009C0C0B /* AuthRepositoryTests.swift */; };
-		BE95D1FB28DF348C009C0C0B /* AuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE95D1F628DF2F44009C0C0B /* AuthRepository.swift */; };
-		BE95D1FC28DF3492009C0C0B /* AuthDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413BA28C20DC500171060 /* AuthDto.swift */; };
-		BE95D1FD28DF349D009C0C0B /* AuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9413B828C20A4000171060 /* AuthRouter.swift */; };
 		BE982FB8281D0B33005F71E6 /* TimetableBlocksLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FB7281D0B33005F71E6 /* TimetableBlocksLayer.swift */; };
 		BE982FBC281D5227005F71E6 /* TimePlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FBB281D5227005F71E6 /* TimePlace.swift */; };
 		BE982FBE281D6244005F71E6 /* TimetableBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FBD281D6244005F71E6 /* TimetableBlock.swift */; };
@@ -189,15 +176,12 @@
 		BEEBDFB8286B38B600DB5976 /* SNUTTView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEBDFB7286B38B600DB5976 /* SNUTTView.swift */; };
 		BEEBDFBA286B3A0C00DB5976 /* TabScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEBDFB9286B3A0C00DB5976 /* TabScene.swift */; };
 		BEEBDFBC286B408E00DB5976 /* LectureBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEBDFBB286B408E00DB5976 /* LectureBlocks.swift */; };
+		BEF9233828E84653004AFCB2 /* LectureTimeSheetScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF9233728E84653004AFCB2 /* LectureTimeSheetScene.swift */; };
 		DC1E0ECC28771B32005632A3 /* TimetableRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ECB28771B32005632A3 /* TimetableRepository.swift */; };
-		DC1E0ECD28771B32005632A3 /* TimetableRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ECB28771B32005632A3 /* TimetableRepository.swift */; };
 		DC1E0ECF28772F13005632A3 /* NetworkUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ECE28772F13005632A3 /* NetworkUtils.swift */; };
 		DC1E0ED12877381F005632A3 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ED02877381F005632A3 /* Router.swift */; };
 		DC1E0ED4287738F2005632A3 /* TimetableRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ED3287738F2005632A3 /* TimetableRouter.swift */; };
 		DC1E0ED62877E32D005632A3 /* TimetableRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ED52877E32D005632A3 /* TimetableRepositoryTests.swift */; };
-		DC1E0ED72877E3B3005632A3 /* TimetableRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ED3287738F2005632A3 /* TimetableRouter.swift */; };
-		DC1E0ED82877E3CC005632A3 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ED02877381F005632A3 /* Router.swift */; };
-		DC1E0ED92877E78C005632A3 /* NetworkUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1E0ECE28772F13005632A3 /* NetworkUtils.swift */; };
 		DC2915992865D69700FE5F9A /* LectureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2915982865D69700FE5F9A /* LectureListViewModel.swift */; };
 		DC29159B2865F95100FE5F9A /* SettingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159A2865F95100FE5F9A /* SettingScene.swift */; };
 		DC29159D2865FA2800FE5F9A /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29159C2865FA2800FE5F9A /* SettingViewModel.swift */; };
@@ -294,6 +278,8 @@
 		B8F40EB228980DFF0021A2A9 /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		B8F40EB628980E7A0021A2A9 /* AccountSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingViewModel.swift; sourceTree = "<group>"; };
 		B8F570A5289E1221005C199F /* UserDefaults+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+ext.swift"; sourceTree = "<group>"; };
+		BE060BD628DF43AC00A2F1B9 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		BE060BD828DF4C1E00A2F1B9 /* LoginScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScene.swift; sourceTree = "<group>"; };
 		BE0743DC28DC08CE00999F86 /* TestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 		BE13C5B428AE4CBA0081D0AB /* UserDefaultsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsRepository.swift; sourceTree = "<group>"; };
 		BE1B610B289D7C2500401361 /* GlobalUIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalUIService.swift; sourceTree = "<group>"; };
@@ -405,6 +391,7 @@
 		BEEBDFB7286B38B600DB5976 /* SNUTTView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNUTTView.swift; sourceTree = "<group>"; };
 		BEEBDFB9286B3A0C00DB5976 /* TabScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScene.swift; sourceTree = "<group>"; };
 		BEEBDFBB286B408E00DB5976 /* LectureBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureBlocks.swift; sourceTree = "<group>"; };
+		BEF9233728E84653004AFCB2 /* LectureTimeSheetScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LectureTimeSheetScene.swift; sourceTree = "<group>"; };
 		DC1E0ECB28771B32005632A3 /* TimetableRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableRepository.swift; sourceTree = "<group>"; };
 		DC1E0ECE28772F13005632A3 /* NetworkUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUtils.swift; sourceTree = "<group>"; };
 		DC1E0ED02877381F005632A3 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
@@ -740,6 +727,7 @@
 			children = (
 				DCD41A6227E5CCD500CF380E /* TimetableService.swift */,
 				BEDE34D72879A9DC00525014 /* UserService.swift */,
+				BE060BD628DF43AC00A2F1B9 /* AuthService.swift */,
 				BE682BDA28870872009EBCB7 /* LectureService.swift */,
 				BE77D0A628AEB0650067A9D8 /* CourseBookService.swift */,
 				BE9413CF28C220C900171060 /* NotificationService.swift */,
@@ -792,6 +780,8 @@
 				BEDF507227F427FA00CDCC13 /* LectureListScene.swift */,
 				BEDF506E27EB744A00CDCC13 /* LectureDetailScene.swift */,
 				DC29159E28660F7800FE5F9A /* ReviewScene.swift */,
+				BEF9233728E84653004AFCB2 /* LectureTimeSheetScene.swift */,
+				BE060BD828DF4C1E00A2F1B9 /* LoginScene.swift */,
 				BECDB8992840CFAA00F62AC8 /* MenuSheetScene.swift */,
 				BE8BB3B4285D97A600070A66 /* FilterSheetScene.swift */,
 				BE9413E028CCD04900171060 /* LectureTimeSheetScene.swift */,
@@ -1070,6 +1060,7 @@
 				BEE5CE10289E738900CF5ED3 /* MenuThemeSheet.swift in Sources */,
 				BE9413C128C219AD00171060 /* Notification.swift in Sources */,
 				B87B317328D81447005C170B /* UserDto.swift in Sources */,
+				BE060BD928DF4C1E00A2F1B9 /* LoginScene.swift in Sources */,
 				BE682BFF2888056C009EBCB7 /* Quarter.swift in Sources */,
 				B8F40EA9289809C60021A2A9 /* LicenseView.swift in Sources */,
 				BEDF506D27EB740F00CDCC13 /* LectureList.swift in Sources */,
@@ -1089,6 +1080,7 @@
 				BE682BF128872315009EBCB7 /* STError.swift in Sources */,
 				B87B315F28D5A70F005C170B /* TimetableState.swift in Sources */,
 				BEEBDFBA286B3A0C00DB5976 /* TabScene.swift in Sources */,
+				BEF9233828E84653004AFCB2 /* LectureTimeSheetScene.swift in Sources */,
 				DC29159D2865FA2800FE5F9A /* SettingViewModel.swift in Sources */,
 				DC1E0ED12877381F005632A3 /* Router.swift in Sources */,
 				B87B315D28D5A70F005C170B /* UserState.swift in Sources */,
@@ -1113,7 +1105,6 @@
 				BE98A00C288A9E2A00C2CE95 /* MenuSection.swift in Sources */,
 				BEB3B6A528CDE1FD00E56062 /* TimeUtils.swift in Sources */,
 				B8F40EB128980DE00021A2A9 /* TermsOfServiceView.swift in Sources */,
-				DC2915A32866958100FE5F9A /* User.swift in Sources */,
 				BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */,
 				BEDE34CA28754F3100525014 /* Sheet.swift in Sources */,
 				BEB3B6B128D4D4D900E56062 /* View+ResignResponder.swift in Sources */,
@@ -1123,10 +1114,7 @@
 				B87431CB283B5A7300D78C59 /* BaseViewModel.swift in Sources */,
 				BE13C5B528AE4CBA0081D0AB /* UserDefaultsRepository.swift in Sources */,
 				B8E51E6628B5EC500065248E /* NetworkConfiguration.swift in Sources */,
-				BE98A00E288AA3D200C2CE95 /* MenuSheet.swift in Sources */,
-				DC2915A92866986600FE5F9A /* SystemState.swift in Sources */,
 				BE2EA7B128D479BE007C0998 /* Publisher+SinkWithAnimation.swift in Sources */,
-				BE98A00E288AA3D200C2CE95 /* MenuSheet.swift in Sources */,
 				BEDF507527F4289B00CDCC13 /* Lecture.swift in Sources */,
 				BECDB89A2840CFAA00F62AC8 /* MenuSheetScene.swift in Sources */,
 				B87B316728D753A3005C170B /* SettingsMenu.swift in Sources */,
@@ -1178,6 +1166,7 @@
 				BE9413D228C2458A00171060 /* DateFormatter+Parse.swift in Sources */,
 				BE9413C328C21D1000171060 /* NotificationRepository.swift in Sources */,
 				B87B315E28D5A70F005C170B /* SearchState.swift in Sources */,
+				BE060BD728DF43AC00A2F1B9 /* AuthService.swift in Sources */,
 				BE682C012888173B009EBCB7 /* TagRouter.swift in Sources */,
 				BE682BFB2887FC27009EBCB7 /* SearchTagDto.swift in Sources */,
 				BEB57C2128B6758200279EFF /* Animation+Custom.swift in Sources */,
@@ -1204,7 +1193,6 @@
 				B8F40EAD28980D840021A2A9 /* TimetableSettingScene.swift in Sources */,
 				DC860F4927E5C87D0068C94B /* SNUTTApp.swift in Sources */,
 				B827A903289BEB7C00ABAE39 /* SNUTTDefaultsContainer.swift in Sources */,
-				BE9413E128CCD04900171060 /* LectureTimeSheetScene.swift in Sources */,
 				BE9413D028C220C900171060 /* NotificationService.swift in Sources */,
 				BE9413B928C20A4000171060 /* AuthRouter.swift in Sources */,
 				BE682BDB28870872009EBCB7 /* LectureService.swift in Sources */,
@@ -1221,31 +1209,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DC1E0ED72877E3B3005632A3 /* TimetableRouter.swift in Sources */,
 				BE0743DD28DC08CE00999F86 /* TestUtils.swift in Sources */,
-				DC1E0ED92877E78C005632A3 /* NetworkUtils.swift in Sources */,
 				DC1E0ED62877E32D005632A3 /* TimetableRepositoryTests.swift in Sources */,
-				BE682BDE28870C5B009EBCB7 /* Lecture.swift in Sources */,
-				BE682BDC28870C4C009EBCB7 /* TimetableDto.swift in Sources */,
-				BE682BDF28870C69009EBCB7 /* Timetable.swift in Sources */,
-				BE95D1F128DC22DB009C0C0B /* STError.swift in Sources */,
-				BE0743E528DC0AC900999F86 /* CourseBookDto.swift in Sources */,
-				BE95D1FB28DF348C009C0C0B /* AuthRepository.swift in Sources */,
-				BE0743E628DC0AD100999F86 /* NetworkConfiguration.swift in Sources */,
-				DC1E0ED82877E3CC005632A3 /* Router.swift in Sources */,
-				BE779B0528E32882009960EB /* Quarter.swift in Sources */,
-				BE682BE128870C71009EBCB7 /* Weekday.swift in Sources */,
+				BE060C1228DF573900A2F1B9 /* UserDefaults+ext.swift in Sources */,
 				DC860F5A27E5C87F0068C94B /* SNUTTTests.swift in Sources */,
 				BE95D1F928DF32EC009C0C0B /* AuthRepositoryTests.swift in Sources */,
-				BE779B0628E32888009960EB /* TimeUtils.swift in Sources */,
-				BE95D1FC28DF3492009C0C0B /* AuthDto.swift in Sources */,
-				BE682BE028870C6E009EBCB7 /* Theme.swift in Sources */,
-				DC1E0ECD28771B32005632A3 /* TimetableRepository.swift in Sources */,
 				BE0743E128DC0A6500999F86 /* STColor.swift in Sources */,
 				BE682BD3288676FA009EBCB7 /* LectureRepositoryTests.swift in Sources */,
-				BE95D1FD28DF349D009C0C0B /* AuthRouter.swift in Sources */,
-				BE0743E328DC0ABC00999F86 /* ErrorDto.swift in Sources */,
-				BE779B0728E328A7009960EB /* TimePlace.swift in Sources */,
 				BE0743E228DC0A6700999F86 /* STFont.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SNUTT-2022/SNUTT/AppState/AppEnvironment.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppEnvironment.swift
@@ -52,11 +52,11 @@ extension AppEnvironment {
         let dbRepos = configuredDBRepositories(appState: appState)
         let services = configuredServices(appState: appState, webRepositories: webRepos, localRepositories: dbRepos)
         let container = DIContainer(appState: appState, services: services)
-        
+
         /// We need to load access token ASAP in order to determine which screen to show first.
         /// Note that this should run synchronously on the main thread.
         services.authService.loadAccessTokenDuringBootstrap()
-        
+
         return .init(container: container)
     }
 
@@ -132,8 +132,7 @@ extension EnvironmentValues {
                   globalUIService: GlobalUIService(appState: appState),
                   courseBookService: FakeCourseBookService(),
                   authService: FakeAuthService(),
-                  notificationService: FakeNotificationService()
-            )
+                  notificationService: FakeNotificationService())
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/AppState/AppEnvironment.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppEnvironment.swift
@@ -22,6 +22,7 @@ extension AppEnvironment {
         let reviewService: ReviewServiceProtocol
         let globalUIService: GlobalUIServiceProtocol
         let courseBookService: CourseBookServiceProtocol
+        let authService: AuthServiceProtocol
         let notificationService: NotificationServiceProtocol
     }
 }
@@ -34,6 +35,7 @@ extension AppEnvironment {
         let searchRepository: SearchRepositoryProtocol
         let courseBookRepository: CourseBookRepositoryProtocol
         let reviewRepository: ReviewRepositoryProtocol
+        let authRepository: AuthRepositoryProtocol
         let notificationRepository: NotificationRepositoryProtocol
     }
 
@@ -45,19 +47,21 @@ extension AppEnvironment {
 extension AppEnvironment {
     static func bootstrap() -> Self {
         let appState = AppState()
-        let session = configuredSession()
+        let session = configuredSession(appState: appState)
         let webRepos = configuredWebRepositories(session: session)
         let dbRepos = configuredDBRepositories(appState: appState)
         let services = configuredServices(appState: appState, webRepositories: webRepos, localRepositories: dbRepos)
         let container = DIContainer(appState: appState, services: services)
+        
+        /// We need to load access token ASAP in order to determine which screen to show first.
+        /// Note that this should run synchronously on the main thread.
+        services.authService.loadAccessTokenDuringBootstrap()
+        
         return .init(container: container)
     }
 
-    private static func configuredSession() -> Session {
-        let storage = Storage()
-        storage.apiKey = Bundle.main.infoDictionary?["API_KEY"] as! String
-        storage.accessToken = "74280a42...."
-        return Session(interceptor: Interceptor(authStorage: storage), eventMonitors: [Logger()])
+    private static func configuredSession(appState: AppState) -> Session {
+        return Session(interceptor: Interceptor(userState: appState.user), eventMonitors: [Logger()])
     }
 
     private static func configuredWebRepositories(session: Session) -> WebRepositories {
@@ -67,6 +71,7 @@ extension AppEnvironment {
         let searchRepository = SearchRepository(session: session)
         let reviewRepository = ReviewRepository(session: session)
         let courseBookRepository = CourseBookRepository(session: session)
+        let authRepository = AuthRepository(session: session)
         let notificationRepository = NotificationRepository(session: session)
         return .init(timetableRepository: timetableRepository,
                      userRepository: userRepository,
@@ -74,6 +79,7 @@ extension AppEnvironment {
                      searchRepository: searchRepository,
                      courseBookRepository: courseBookRepository,
                      reviewRepository: reviewRepository,
+                     authRepository: authRepository,
                      notificationRepository: notificationRepository)
     }
 
@@ -90,6 +96,7 @@ extension AppEnvironment {
         let reviewService = ReviewService(appState: appState)
         let globalUIService = GlobalUIService(appState: appState)
         let courseBookService = CourseBookService(appState: appState, webRepositories: webRepositories)
+        let authService = AuthService(appState: appState, webRepositories: webRepositories, localRepositories: localRepositories)
         let notificationService = NotificationService(appState: appState, webRepositories: webRepositories)
         return .init(timetableService: timetableService,
                      userService: userService,
@@ -98,6 +105,7 @@ extension AppEnvironment {
                      reviewService: reviewService,
                      globalUIService: globalUIService,
                      courseBookService: courseBookService,
+                     authService: authService,
                      notificationService: notificationService)
     }
 }
@@ -123,7 +131,9 @@ extension EnvironmentValues {
                   reviewService: FakeReviewService(),
                   globalUIService: GlobalUIService(appState: appState),
                   courseBookService: FakeCourseBookService(),
-                  notificationService: FakeNotificationService())
+                  authService: FakeAuthService(),
+                  notificationService: FakeNotificationService()
+            )
         }
     }
 #endif

--- a/SNUTT-2022/SNUTT/AppState/States/UserState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/UserState.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 class UserState: ObservableObject {
-    
     // TODO: deprecated. this is not a state
     let apiKey: String? = Bundle.main.infoDictionary?["API_KEY"] as? String
-    
+
     @Published var accessToken: String?
     @Published var current: User?
 }

--- a/SNUTT-2022/SNUTT/AppState/States/UserState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/UserState.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 
 class UserState: ObservableObject {
-    var token: String?
-    var apiKey: String?
+    
+    // TODO: deprecated. this is not a state
+    let apiKey: String? = Bundle.main.infoDictionary?["API_KEY"] as? String
+    
+    @Published var accessToken: String?
     @Published var current: User?
 }

--- a/SNUTT-2022/SNUTT/Repositories/NetworkUtils.swift
+++ b/SNUTT-2022/SNUTT/Repositories/NetworkUtils.swift
@@ -8,26 +8,18 @@
 import Alamofire
 import Foundation
 
-/// 적절한 장소로 옮겨야
-protocol AuthStorage {
-    typealias ApiKey = String
-    typealias AccessToken = String
-    var apiKey: ApiKey { get set }
-    var accessToken: AccessToken { get set }
-}
-
 final class Interceptor: RequestInterceptor {
-    private let authStorage: AuthStorage
+    private let userState: UserState
 
-    init(authStorage: AuthStorage) {
-        self.authStorage = authStorage
+    init(userState: UserState) {
+        self.userState = userState
     }
 
     func adapt(_ urlRequest: URLRequest, for _: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         var urlRequest = urlRequest
 
-        urlRequest.setValue(authStorage.apiKey, forHTTPHeaderField: "x-access-apikey")
-        urlRequest.setValue(authStorage.accessToken, forHTTPHeaderField: "x-access-token")
+        urlRequest.setValue(Bundle.main.infoDictionary?["API_KEY"] as? String, forHTTPHeaderField: "x-access-apikey")
+        urlRequest.setValue(userState.accessToken, forHTTPHeaderField: "x-access-token")
 
         completion(.success(urlRequest))
     }

--- a/SNUTT-2022/SNUTT/Services/AuthService.swift
+++ b/SNUTT-2022/SNUTT/Services/AuthService.swift
@@ -1,0 +1,50 @@
+//
+//  AuthService.swift
+//  SNUTT
+//
+//  Created by 박신홍 on 2022/09/24.
+//
+
+import Foundation
+
+protocol AuthServiceProtocol {
+    func loadAccessTokenDuringBootstrap()
+    func loginWithId(id:String, password:String) async throws
+}
+
+struct AuthService: AuthServiceProtocol {
+    let appState: AppState
+    let webRepositories: AppEnvironment.WebRepositories
+    var localRepositories: AppEnvironment.LocalRepositories
+
+    var userRepository: UserRepositoryProtocol {
+        webRepositories.userRepository
+    }
+    
+    var authRepository: AuthRepositoryProtocol {
+        webRepositories.authRepository
+    }
+
+    var userDefaultsRepository: UserDefaultsRepositoryProtocol {
+        localRepositories.userDefaultsRepository
+    }
+    
+    func loadAccessTokenDuringBootstrap() {
+        /// **DO NOT RUN THIS CODE ASYNCHRONOUSLY**. We need to show splash screen until the loading finishes.
+        appState.user.accessToken = userDefaultsRepository.get(String.self, key: .token)
+//        appState.user.accessToken = nil
+    }
+    
+    func loginWithId(id:String, password:String) async throws {
+        let dto = try await authRepository.loginWithId(id: id, password: password)
+        DispatchQueue.main.async {
+            appState.user.accessToken = dto.token
+        }
+        userDefaultsRepository.set(String.self, key: .token, value: dto.token)
+    }
+}
+
+class FakeAuthService: AuthServiceProtocol {
+    func loadAccessTokenDuringBootstrap() {}
+    func loginWithId(id:String, password:String) async throws {}
+}

--- a/SNUTT-2022/SNUTT/Services/AuthService.swift
+++ b/SNUTT-2022/SNUTT/Services/AuthService.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol AuthServiceProtocol {
     func loadAccessTokenDuringBootstrap()
-    func loginWithId(id:String, password:String) async throws
+    func loginWithId(id: String, password: String) async throws
 }
 
 struct AuthService: AuthServiceProtocol {
@@ -20,7 +20,7 @@ struct AuthService: AuthServiceProtocol {
     var userRepository: UserRepositoryProtocol {
         webRepositories.userRepository
     }
-    
+
     var authRepository: AuthRepositoryProtocol {
         webRepositories.authRepository
     }
@@ -28,14 +28,14 @@ struct AuthService: AuthServiceProtocol {
     var userDefaultsRepository: UserDefaultsRepositoryProtocol {
         localRepositories.userDefaultsRepository
     }
-    
+
     func loadAccessTokenDuringBootstrap() {
         /// **DO NOT RUN THIS CODE ASYNCHRONOUSLY**. We need to show splash screen until the loading finishes.
         appState.user.accessToken = userDefaultsRepository.get(String.self, key: .token)
 //        appState.user.accessToken = nil
     }
-    
-    func loginWithId(id:String, password:String) async throws {
+
+    func loginWithId(id: String, password: String) async throws {
         let dto = try await authRepository.loginWithId(id: id, password: password)
         DispatchQueue.main.async {
             appState.user.accessToken = dto.token
@@ -46,5 +46,5 @@ struct AuthService: AuthServiceProtocol {
 
 class FakeAuthService: AuthServiceProtocol {
     func loadAccessTokenDuringBootstrap() {}
-    func loginWithId(id:String, password:String) async throws {}
+    func loginWithId(id _: String, password _: String) async throws {}
 }

--- a/SNUTT-2022/SNUTT/Services/TimetableService.swift
+++ b/SNUTT-2022/SNUTT/Services/TimetableService.swift
@@ -45,9 +45,9 @@ struct TimetableService: TimetableServiceProtocol {
             let localTimetable = Timetable(from: localData)
             if appState.user.current?.localId == localTimetable.userId {
                 await updateState(to: localTimetable) // 일단 저장된 시간표로 상태 업데이트
+                try await fetchTimetable(timetableId: localTimetable.id) // API 요청을 통해 시간표 최신화
+                return
             }
-            try await fetchTimetable(timetableId: localTimetable.id) // API 요청을 통해 시간표 최신화
-            return
         }
         let dto = try await timetableRepository.fetchRecentTimetable()
         userDefaultsRepository.set(TimetableDto.self, key: .currentTimetable, value: dto)

--- a/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/ReviewViewModel.swift
@@ -47,7 +47,7 @@ class ReviewViewModel: BaseViewModel, ObservableObject {
     }
 
     var token: String? {
-        appState.user.token
+        appState.user.accessToken
     }
 
     private var webViewState: WebViewState {

--- a/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTApp.swift
@@ -7,12 +7,6 @@
 
 import SwiftUI
 
-// TODO: change this
-class Storage: AuthStorage {
-    var apiKey: ApiKey = ""
-    var accessToken: AccessToken = ""
-}
-
 @main
 struct SNUTTApp: App {
     let appEnvironment: AppEnvironment

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -17,7 +17,7 @@ struct SNUTTView: View {
 
     var body: some View {
         ZStack {
-            if viewModel.accessToken == nil {
+            if !viewModel.isAuthenticated {
                 LoginScene(viewModel: .init(container: viewModel.container))
                     .transition(.move(edge: .bottom))
             } else {
@@ -66,6 +66,11 @@ extension SNUTTView {
         @Published var isErrorAlertPresented = false
         @Published var errorContent: STError? = nil
         @Published var accessToken: String? = nil
+
+        var isAuthenticated: Bool {
+            guard let accessToken = accessToken else { return false }
+            return !accessToken.isEmpty
+        }
 
         override init(container: DIContainer) {
             super.init(container: container)

--- a/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 struct LoginScene: View {
     @ObservedObject var viewModel: ViewModel
-    
+
     @State private var id: String = "snuttiostest123"
     @State private var password: String = "snuttiostest123"
-    
+
     var body: some View {
         VStack {
             TextField("아이디", text: $id)
@@ -26,20 +26,16 @@ struct LoginScene: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.blue)
-
         }
-        
     }
 }
 
 extension LoginScene {
-    class ViewModel: BaseViewModel, ObservableObject {
-        
-    }
+    class ViewModel: BaseViewModel, ObservableObject {}
 }
 
-//struct LoginScene_Previews: PreviewProvider {
+// struct LoginScene_Previews: PreviewProvider {
 //    static var previews: some View {
 //        LoginScene()
 //    }
-//}
+// }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
@@ -1,0 +1,45 @@
+//
+//  LoginScene.swift
+//  SNUTT
+//
+//  Created by 박신홍 on 2022/09/24.
+//
+
+import SwiftUI
+
+struct LoginScene: View {
+    @ObservedObject var viewModel: ViewModel
+    
+    @State private var id: String = "snuttiostest123"
+    @State private var password: String = "snuttiostest123"
+    
+    var body: some View {
+        VStack {
+            TextField("아이디", text: $id)
+            TextField("비밀번호", text: $password)
+            Button {
+                Task {
+                    try! await viewModel.container.services.authService.loginWithId(id: id, password: password)
+                }
+            } label: {
+                Text("로그인")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.blue)
+
+        }
+        
+    }
+}
+
+extension LoginScene {
+    class ViewModel: BaseViewModel, ObservableObject {
+        
+    }
+}
+
+//struct LoginScene_Previews: PreviewProvider {
+//    static var previews: some View {
+//        LoginScene()
+//    }
+//}

--- a/SNUTT-2022/SNUTTTests/AuthRepositoryTests.swift
+++ b/SNUTT-2022/SNUTTTests/AuthRepositoryTests.swift
@@ -7,6 +7,7 @@
 
 import Alamofire
 import XCTest
+@testable import SNUTT
 
 class AuthRepositoryTests: XCTestCase {
     let repository = AuthRepository(session: .test)

--- a/SNUTT-2022/SNUTTTests/AuthRepositoryTests.swift
+++ b/SNUTT-2022/SNUTTTests/AuthRepositoryTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Alamofire
-import XCTest
 @testable import SNUTT
+import XCTest
 
 class AuthRepositoryTests: XCTestCase {
     let repository = AuthRepository(session: .test)

--- a/SNUTT-2022/SNUTTTests/TestUtils.swift
+++ b/SNUTT-2022/SNUTTTests/TestUtils.swift
@@ -7,16 +7,25 @@
 
 import Alamofire
 import Foundation
+@testable import SNUTT
 
 extension Session {
     static var test: Session {
-        Session(interceptor: Interceptor(authStorage: TestAuthStorage()), eventMonitors: [Logger()])
+        Session(interceptor: Interceptor(userState: AppState.test.user), eventMonitors: [Logger()])
     }
 }
 
-class TestAuthStorage: AuthStorage {
-    var apiKey: ApiKey = Bundle.main.infoDictionary?["API_KEY"] as! String
-    var accessToken: AccessToken = Bundle.main.infoDictionary?["ACCESS_TOKEN_TEST"] as! String
+extension AppState {
+    static var test: AppState = {
+        let state = AppState()
+        state.user.accessToken = TestStorage.accessToken
+        return state
+    }()
+}
+
+struct TestStorage {
+    static var apiKey: String = Bundle.main.infoDictionary?["API_KEY"] as! String
+    static var accessToken: String = Bundle.main.infoDictionary?["ACCESS_TOKEN_TEST"] as! String
 }
 
 struct TestUtils {

--- a/SNUTT-2022/SNUTTTests/TimetableRepositoryTests.swift
+++ b/SNUTT-2022/SNUTTTests/TimetableRepositoryTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Alamofire
-import XCTest
 @testable import SNUTT
+import XCTest
 
 class TimetableRepositoryTests: XCTestCase {
     let repository = TimetableRepository(session: .test)

--- a/SNUTT-2022/SNUTTTests/TimetableRepositoryTests.swift
+++ b/SNUTT-2022/SNUTTTests/TimetableRepositoryTests.swift
@@ -7,6 +7,7 @@
 
 import Alamofire
 import XCTest
+@testable import SNUTT
 
 class TimetableRepositoryTests: XCTestCase {
     let repository = TimetableRepository(session: .test)


### PR DESCRIPTION
- #120 에서 분기한 브랜치입니다.

주요 변경사항은 아래와 같습니다.

- AuthService를 추가했습니다. 
- token이 주입되고 관리되는 방식을 변경했습니다.
    - (기존) `AppEnvironment`의 `bootstrap` 과정에서 생성하는 `Session`에 토큰 주입
    - (문제) 토큰이 변경되었을 경우, 새로운 토큰으로 `Session` 객체를 다시 생성한 뒤 Repository들을 돌면서 Session을 교체하거나,  `(session.intercepter as! Intercepter).authStorage.token = newToken`과 같이 다소 번거롭게 수정해야 함
    - (수정) `AuthStorage` 대신 `UserState`가 token에 대한 single source of truth로 작동하게끔 변경. `Intercepter`는 `userState`를 참조해서 token을 실시간으로 헤더에 반영하도록 함. 이에 따라 `AuthStorage`와 하위 구현체들은 삭제.
- `token` -> `accessToken`으로 리네임 (fcmToken, Apple Token 등과 구분하기 위해)
- `UserState`에 `apiKey`가 있는데, 이건 state가 아니라 앱의 환경변수에 가까우므로 추후에 deprecate할 예정입니다.
- 아주 간단한 로그인 뷰를 추가했습니다. (화면 전환 등 기능 잘 작동하는지 확인용)
- Auth 관련 테스트 일부 작성
    - `@testable import SNUTT`를 사용하면 타겟 멤버십에 SNUTTTest를 추가할 필요가 없습니다. 이에 따라 테스트 관련 타겟 멤버십 모두 제거했습니다.