### PR TITLE
강의 시간 로직 변경

### DIFF
--- a/SNUTT-2022/SNUTT/Models/Lecture.swift
+++ b/SNUTT-2022/SNUTT/Models/Lecture.swift
@@ -12,7 +12,6 @@ struct Lecture: Identifiable {
     let id: String
     var title: String
     var instructor: String
-    var timeString: String
     var timePlaces: [TimePlace]
     let timeMasks: [Int]
     var courseNumber: String
@@ -65,8 +64,22 @@ struct Lecture: Identifiable {
         return lecture
     }
 
-    var startDateTimeString: String {
-        timePlaces.map { $0.startDateTimeString }.joined(separator: "/")
+    var preciseTimeString: String {
+        if timePlaces.isEmpty {
+            return ""
+        }
+        return timePlaces.map { $0.preciseTimeString }.joined(separator: ", ")
+    }
+    
+    var placesString: String {
+        if timePlaces.isEmpty {
+            return ""
+        }
+        let places = timePlaces.compactMap { $0.place.isEmpty ? nil : $0.place }
+        if places.isEmpty {
+            return ""
+        }
+        return places.joined(separator: ", ")
     }
 }
 
@@ -82,7 +95,6 @@ extension Lecture {
         id = dto._id
         title = dto.course_title
         instructor = dto.instructor
-        timeString = dto.class_time ?? ""
         timePlaces = dto.class_time_json.map { .init(from: $0, isCustom: dto.course_number == nil) }
         timeMasks = dto.class_time_mask ?? []
         isCustom = (dto.course_number == nil || dto.course_number == "")
@@ -114,7 +126,6 @@ extension Lecture {
             return Lecture(id: UUID().uuidString,
                            title: titles.randomElement()!,
                            instructor: instructors.randomElement()!,
-                           timeString: "월(6-1.5)/수(6-1.5)",
                            timePlaces: [.preview, .preview],
                            timeMasks: [],
                            courseNumber: "400.313",

--- a/SNUTT-2022/SNUTT/Models/Lecture.swift
+++ b/SNUTT-2022/SNUTT/Models/Lecture.swift
@@ -70,7 +70,7 @@ struct Lecture: Identifiable {
         }
         return timePlaces.map { $0.preciseTimeString }.joined(separator: ", ")
     }
-    
+
     var placesString: String {
         if timePlaces.isEmpty {
             return ""

--- a/SNUTT-2022/SNUTT/Models/TimePlace.swift
+++ b/SNUTT-2022/SNUTT/Models/TimePlace.swift
@@ -13,7 +13,7 @@ struct TimePlace: Identifiable {
     var day: Weekday
 
     var startTime: String
-    
+
     var endTime: String
 
     var place: String
@@ -23,19 +23,19 @@ struct TimePlace: Identifiable {
     /// `true` if and only if this `TimePlace` object is created locally, but not committed to the server yet.
     /// This flag is necessary in order to remove `_id` field for newly created objects, before comitting to the server.
     var isTemporary: Bool = false
-    
+
     var startTimeDouble: Double {
         return TimeUtils.getTimeInDouble(from: startTime)
     }
-    
+
     var endTimeDouble: Double {
         return TimeUtils.getTimeInDouble(from: endTime)
     }
-    
+
     var duration: Double {
         return endTimeDouble - startTimeDouble
     }
-    
+
     var preciseTimeString: String {
         return "\(day.veryShortSymbol)(\(startTime)~\(endTime))"
     }

--- a/SNUTT-2022/SNUTT/Models/TimePlace.swift
+++ b/SNUTT-2022/SNUTT/Models/TimePlace.swift
@@ -12,13 +12,9 @@ struct TimePlace: Identifiable {
 
     var day: Weekday
 
-    /// 단위: 교시
-    var start: Double
-
-    /// 단위: 시간
-    ///
-    /// - TODO: 서버에서 내려주는 시간은 0.5의 배수이다. 따라서 강의가 끝나는 시각을 정확하게 나타내기 위해서는 적절한 보정이 필요하다.
-    var len: Double
+    var startTime: String
+    
+    var endTime: String
 
     var place: String
 
@@ -27,38 +23,39 @@ struct TimePlace: Identifiable {
     /// `true` if and only if this `TimePlace` object is created locally, but not committed to the server yet.
     /// This flag is necessary in order to remove `_id` field for newly created objects, before comitting to the server.
     var isTemporary: Bool = false
-
-    /// 단위: 시각
-    ///
-    /// 7.5교시는 오후 15시 30분을 의미한다.
-    var startTime: Double {
-        get { start + 8 }
-        set { start = newValue - 8 }
+    
+    var startTimeDouble: Double {
+        return TimeUtils.getTimeInDouble(from: startTime)
     }
-
-    var endTime: Double {
-        startTime + len
+    
+    var endTimeDouble: Double {
+        return TimeUtils.getTimeInDouble(from: endTime)
     }
-
+    
+    var duration: Double {
+        return endTimeDouble - startTimeDouble
+    }
+    
+    // TODO: use better format
     var startTimeString: String {
-        TimeUtils.getPreciseHourMinuteString(from: startTime)
+        return startTime
     }
 
     var endTimeString: String {
-        TimeUtils.getPreciseHourMinuteString(from: endTime)
+        return endTime
     }
 
     /// `월7`(월요일 7교시)과 같이 표기한다.
     var startDateTimeString: String {
-        TimeUtils.getStartDateTimeString(day: day, classPeriod: start)
+        return startTime
     }
 }
 
 extension TimePlace {
     init(from dto: TimePlaceDto, isCustom: Bool) {
         id = dto._id ?? UUID().description
-        start = dto.start
-        len = dto.len
+        startTime = dto.start_time
+        endTime = dto.end_time
         place = dto.place
         day = .init(rawValue: dto.day) ?? .mon
         self.isCustom = isCustom
@@ -71,8 +68,8 @@ extension TimePlace {
             let place = "\(Int.random(in: 100 ... 999))-\(Int.random(in: 100 ... 999))"
             return TimePlace(id: UUID().uuidString,
                              day: .init(rawValue: Int.random(in: 0 ... 6))!,
-                             start: Double.random(in: 1 ... 8),
-                             len: Double.random(in: 0 ... 3),
+                             startTime: "15:00",
+                             endTime: "18:15",
                              place: place,
                              isCustom: Bool.random())
         }

--- a/SNUTT-2022/SNUTT/Models/TimePlace.swift
+++ b/SNUTT-2022/SNUTT/Models/TimePlace.swift
@@ -36,18 +36,8 @@ struct TimePlace: Identifiable {
         return endTimeDouble - startTimeDouble
     }
     
-    // TODO: use better format
-    var startTimeString: String {
-        return startTime
-    }
-
-    var endTimeString: String {
-        return endTime
-    }
-
-    /// `월7`(월요일 7교시)과 같이 표기한다.
-    var startDateTimeString: String {
-        return startTime
+    var preciseTimeString: String {
+        return "\(day.veryShortSymbol)(\(startTime)~\(endTime))"
     }
 }
 

--- a/SNUTT-2022/SNUTT/Models/Timetable.swift
+++ b/SNUTT-2022/SNUTT/Models/Timetable.swift
@@ -53,11 +53,11 @@ struct Timetable {
     }
 
     var earliestStartTime: Double? {
-        aggregatedTimePlaces.min(by: { $0.startTime < $1.startTime })?.startTime
+        aggregatedTimePlaces.min(by: { $0.startTimeDouble < $1.startTimeDouble })?.startTimeDouble
     }
 
     var lastEndTime: Double? {
-        aggregatedTimePlaces.max(by: { $0.endTime < $1.endTime })?.endTime
+        aggregatedTimePlaces.max(by: { $0.endTimeDouble < $1.endTimeDouble })?.endTimeDouble
     }
 
     func withSelectedLecture(_ lecture: Lecture?) -> Self {

--- a/SNUTT-2022/SNUTT/Repositories/Dto/TimetableDto.swift
+++ b/SNUTT-2022/SNUTT/Repositories/Dto/TimetableDto.swift
@@ -48,8 +48,8 @@ struct LectureColorDto: Codable {
 struct TimePlaceDto: Codable {
     let _id: String?
     let day: Int
-    let start: Double
-    let len: Double
+    let start_time: String
+    let end_time: String
     let place: String
 }
 
@@ -91,8 +91,8 @@ extension TimePlaceDto {
     init(from model: TimePlace) {
         _id = model.isTemporary ? nil : model.id
         day = model.day.rawValue
-        start = model.start
-        len = model.len
+        start_time = model.startTime
+        end_time = model.endTime
         place = model.place
     }
 }

--- a/SNUTT-2022/SNUTT/Utils/TimeUtils.swift
+++ b/SNUTT-2022/SNUTT/Utils/TimeUtils.swift
@@ -12,23 +12,33 @@ struct TimeUtils {
         let hour: Int
         let minute: Int
     }
-
+    
     /// 월요일 7교시인 경우 `월7`을 반환한다.
     static func getStartDateTimeString(day: Weekday, classPeriod: Double) -> String {
         return "\(day.shortSymbol)\(String(format: "%g", classPeriod))"
     }
 
     /// `time: Double`을 분 단위로 정확하게 60진법 수로 환산한다.
-    /// ex) 15.3 -> 15시 18분(`0.3 * 60 == 18`)
     static func getPreciseHourMinute(from time: Double) -> Time {
         let hour = Int(time)
         let minute = Int((time.truncatingRemainder(dividingBy: 1) * 60).rounded())
         return .init(hour: hour, minute: minute)
     }
 
-    static func getPreciseHourMinuteString(from time: Double) -> String {
+    static func getTimeInString(from time: Double) -> String {
         let preciseTime = getPreciseHourMinute(from: time)
-        return "\(preciseTime.hour):\(String(format: "%02d", preciseTime.minute))"
+        return "\(String(format: "%02d", preciseTime.hour)):\(String(format: "%02d", preciseTime.minute))"
+    }
+    
+    static func getTimeInString(from date: Date) -> String {
+        let time = getTime(from: date)
+        let timeDouble = getTimeInDouble(from: time)
+        return getTimeInString(from: timeDouble)
+    }
+    
+    static func getDate(from time: String) -> Date? {
+        let timeDouble = getTimeInDouble(from: time)
+        return getDate(from: timeDouble)
     }
 
     static func getDate(from time: Double) -> Date? {
@@ -45,6 +55,12 @@ struct TimeUtils {
         let hour = calendar.component(.hour, from: date)
         let minute = calendar.component(.minute, from: date)
         return .init(hour: hour, minute: minute)
+    }
+    
+    static func getTimeInDouble(from time: String) -> Double {
+        let splitted = time.components(separatedBy: ":")
+        guard let hour = Int(splitted[0]), let minute = Int(splitted[1]) else { return 0 }
+        return getTimeInDouble(from: .init(hour: hour, minute: minute))
     }
 
     static func getTimeInDouble(from time: Time) -> Double {

--- a/SNUTT-2022/SNUTT/Utils/TimeUtils.swift
+++ b/SNUTT-2022/SNUTT/Utils/TimeUtils.swift
@@ -12,7 +12,7 @@ struct TimeUtils {
         let hour: Int
         let minute: Int
     }
-    
+
     /// 월요일 7교시인 경우 `월7`을 반환한다.
     static func getStartDateTimeString(day: Weekday, classPeriod: Double) -> String {
         return "\(day.shortSymbol)\(String(format: "%g", classPeriod))"
@@ -29,13 +29,13 @@ struct TimeUtils {
         let preciseTime = getPreciseHourMinute(from: time)
         return "\(String(format: "%02d", preciseTime.hour)):\(String(format: "%02d", preciseTime.minute))"
     }
-    
+
     static func getTimeInString(from date: Date) -> String {
         let time = getTime(from: date)
         let timeDouble = getTimeInDouble(from: time)
         return getTimeInString(from: timeDouble)
     }
-    
+
     static func getDate(from time: String) -> Date? {
         let timeDouble = getTimeInDouble(from: time)
         return getDate(from: timeDouble)
@@ -56,7 +56,7 @@ struct TimeUtils {
         let minute = calendar.component(.minute, from: date)
         return .init(hour: hour, minute: minute)
     }
-    
+
     static func getTimeInDouble(from time: String) -> Double {
         let splitted = time.components(separatedBy: ":")
         guard let hour = Int(splitted[0]), let minute = Int(splitted[1]) else { return 0 }

--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -140,8 +140,8 @@ extension LectureDetailScene {
             var lecture = lecture
             lecture.timePlaces.append(.init(id: UUID().description,
                                             day: .mon,
-                                            start: 1,
-                                            len: 1,
+                                            startTime: "9:00",
+                                            endTime: "10:00",
                                             place: "",
                                             isCustom: lecture.isCustom,
                                             isTemporary: true))

--- a/SNUTT-2022/SNUTT/ViewModels/LectureListViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureListViewModel.swift
@@ -19,7 +19,7 @@ class LectureListViewModel: BaseViewModel, ObservableObject {
     var placeholderLecture: Lecture {
         var lecture: Lecture = .init(from: .init(_id: UUID().uuidString, classification: nil, department: nil, academic_year: nil, course_title: "새로운 강의", credit: 0, class_time: nil, class_time_json: [], class_time_mask: [], instructor: "", quota: nil, remark: nil, category: nil, course_number: nil, lecture_number: nil, created_at: nil, updated_at: nil, color: nil, colorIndex: 1))
         lecture.theme = appState.timetable.current?.theme ?? .snutt
-        lecture.timePlaces.append(.init(id: UUID().uuidString, day: .mon, start: 1, len: 1, place: "", isCustom: true, isTemporary: true))
+        lecture.timePlaces.append(.init(id: UUID().uuidString, day: .mon, startTime: "9:00", endTime: "10:00", place: "", isCustom: true, isTemporary: true))
         return lecture
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/LectureDetail/EditableFields.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureDetail/EditableFields.swift
@@ -88,7 +88,7 @@ struct EditableTimeField: View {
     @Environment(\.editMode) private var editMode
 
     @ViewBuilder private func timeTextLabel(from timePlace: TimePlace) -> some View {
-        Text("\(timePlace.day.shortSymbol) \(timePlace.startTimeString) ~ \(timePlace.endTimeString)")
+        Text("\(timePlace.day.shortSymbol) \(timePlace.startTime) ~ \(timePlace.endTime)")
     }
 
     var isEditing: Bool {

--- a/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/LectureListCell.swift
@@ -17,12 +17,12 @@ struct LectureListCell: View {
 
             // details
             if lecture.isCustom {
-                LectureDetailRow(imageName: "tag.black", text: "(없음)")
+                LectureDetailRow(imageName: "tag.black", text: "")
             } else {
                 LectureDetailRow(imageName: "tag.black", text: "\(lecture.department), \(lecture.academicYear)")
             }
-            LectureDetailRow(imageName: "clock.black", text: lecture.timeString.isEmpty ? "(없음)" : lecture.timeString)
-            LectureDetailRow(imageName: "map.black", text: lecture.timePlaces.isEmpty ? "(없음)" : lecture.timePlaces.map { $0.place }.joined(separator: "/"))
+            LectureDetailRow(imageName: "clock.black", text: lecture.preciseTimeString)
+            LectureDetailRow(imageName: "map.black", text: lecture.placesString)
         }
         .padding(.vertical, 5)
 
@@ -38,8 +38,13 @@ struct LectureHeaderRow: View {
                 Text(lecture.title)
                     .font(STFont.subheading)
                 Spacer()
-                Text("\(lecture.instructor) / \(lecture.credit)학점")
-                    .font(STFont.details)
+                if lecture.instructor.isEmpty {
+                    Text("\(lecture.credit)학점")
+                        .font(STFont.details)
+                } else {
+                    Text("\(lecture.instructor) / \(lecture.credit)학점")
+                        .font(STFont.details)
+                }
             }
         }
     }
@@ -54,9 +59,10 @@ struct LectureDetailRow: View {
             Image(imageName)
                 .resizable()
                 .frame(width: 15, height: 15)
-            Text(text)
+            Text(text.isEmpty ? "-" : text)
                 .font(STFont.details)
                 .lineLimit(1)
+                .opacity(text.isEmpty ? 0.5 : 1)
             Spacer()
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -31,15 +31,15 @@ struct SearchLectureCell: View {
 
                 // details
                 if lecture.isCustom {
-                    LectureDetailRow(imageName: "tag.white", text: "(없음)")
+                    LectureDetailRow(imageName: "tag.white", text: "")
                 } else {
                     LectureDetailRow(imageName: "tag.white", text: "\(lecture.department), \(lecture.academicYear)")
                 }
-                LectureDetailRow(imageName: "clock.white", text: lecture.startDateTimeString.isEmpty ? "(없음)" : lecture.startDateTimeString)
+                LectureDetailRow(imageName: "clock.white", text: lecture.preciseTimeString)
 
-                LectureDetailRow(imageName: "map.white", text: lecture.timePlaces.isEmpty ? "(없음)" : lecture.timePlaces.map { $0.place }.joined(separator: "/"))
+                LectureDetailRow(imageName: "map.white", text: lecture.placesString)
 
-                LectureDetailRow(imageName: "ellipsis.white", text: lecture.remark.isEmpty ? "(없음)" : lecture.remark)
+                LectureDetailRow(imageName: "ellipsis.white", text: lecture.remark)
 
                 if selected {
                     Spacer().frame(height: 5)

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
@@ -33,7 +33,7 @@ struct TimetablePainter {
         }
 
         let minHour = getStartingHour(current: current, config: config)
-        let hourIndex = timePlace.startTime - Double(minHour)
+        let hourIndex = timePlace.startTimeDouble - Double(minHour)
         guard let weekdayIndex = config.visibleWeeksSorted.firstIndex(of: timePlace.day) else { return nil }
         if hourIndex < 0 {
             return nil
@@ -47,7 +47,7 @@ struct TimetablePainter {
 
     /// 주어진 `TimePlace`블록의 높이를 구한다.
     static func getHeight(of timePlace: TimePlace, in containerSize: CGSize, hourCount: Int) -> CGFloat {
-        return timePlace.len * getHourHeight(in: containerSize, hourCount: hourCount)
+        return timePlace.duration * getHourHeight(in: containerSize, hourCount: hourCount)
     }
 
     // MARK: Auto Fit

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureTimeSheetScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureTimeSheetScene.swift
@@ -50,12 +50,8 @@ extension LectureTimeSheetScene {
 
         private func getSelectedTimePlace() -> TimePlace? {
             guard var initialTimePlace = appState.menu.timePlaceToModify else { return nil }
-            let startDouble = TimeUtils.getTimeInDouble(from: start)
-            let endDouble = TimeUtils.getTimeInDouble(from: end)
-            let len = endDouble - startDouble
-
-            initialTimePlace.startTime = startDouble
-            initialTimePlace.len = len
+            initialTimePlace.startTime = TimeUtils.getTimeInString(from: start)
+            initialTimePlace.endTime = TimeUtils.getTimeInString(from: end)
             initialTimePlace.day = weekday
             return initialTimePlace
         }
@@ -63,7 +59,7 @@ extension LectureTimeSheetScene {
         func initializeTime() {
             guard let initialTimePlace = appState.menu.timePlaceToModify else { return }
             guard let startDate = TimeUtils.getDate(from: initialTimePlace.startTime),
-                  let endDate = TimeUtils.getDate(from: initialTimePlace.startTime + initialTimePlace.len) else { return }
+                  let endDate = TimeUtils.getDate(from: initialTimePlace.endTime) else { return }
             start = startDate
             end = endDate
             weekday = initialTimePlace.day


### PR DESCRIPTION
- `start`, `len`의 흔적을 없앴습니다.
- [여기](https://wafflestudio.slack.com/archives/C8M9NUBBR/p1664813491365339)에서 언급했던 것처럼 시간 표기 로직도 업데이트했습니다.

<img width="551" alt="스크린샷 2022-11-20 오전 11 17 55" src="https://user-images.githubusercontent.com/33917774/202879531-fea1286a-2cad-4b6c-a0ae-dd80030dae99.png">
