### PR TITLE
로그아웃, 회원탈퇴 시 alert / 이메일 필수로 변경 / 시간표 설정 자동맞춤 대응

### DIFF
--- a/SNUTT-2022/SNUTT/Repositories/AuthRepository.swift
+++ b/SNUTT-2022/SNUTT/Repositories/AuthRepository.swift
@@ -9,7 +9,7 @@ import Alamofire
 import Foundation
 
 protocol AuthRepositoryProtocol {
-    func registerWithId(id: String, password: String, email: String?) async throws -> LoginResponseDto
+    func registerWithId(id: String, password: String, email: String) async throws -> LoginResponseDto
     func loginWithApple(token: String) async throws -> LoginResponseDto
     func loginWithFacebook(id: String, token: String) async throws -> LoginResponseDto
     func loginWithId(id: String, password: String) async throws -> LoginResponseDto
@@ -23,7 +23,7 @@ class AuthRepository: AuthRepositoryProtocol {
         self.session = session
     }
 
-    func registerWithId(id: String, password: String, email: String?) async throws -> LoginResponseDto {
+    func registerWithId(id: String, password: String, email: String) async throws -> LoginResponseDto {
         return try await session
             .request(AuthRouter.registerWithId(id: id, password: password, email: email))
             .serializingDecodable(LoginResponseDto.self)

--- a/SNUTT-2022/SNUTT/Repositories/Router/AuthRouter.swift
+++ b/SNUTT-2022/SNUTT/Repositories/Router/AuthRouter.swift
@@ -13,7 +13,7 @@ enum AuthRouter: Router {
     var baseURL: URL { return URL(string: NetworkConfiguration.serverBaseURL + "/auth")! }
     static let shouldAddToken: Bool = false
 
-    case registerWithId(id: String, password: String, email: String?)
+    case registerWithId(id: String, password: String, email: String)
     case loginWithId(id: String, password: String)
     case loginWithFacebook(id: String, token: String)
     case loginWithApple(token: String)
@@ -54,11 +54,7 @@ enum AuthRouter: Router {
         case let .loginWithId(id, password):
             return ["id": id, "password": password]
         case let .registerWithId(id, password, email):
-            var ret = ["id": id, "password": password]
-            if let email = email {
-                ret["email"] = email
-            }
-            return ret
+            return ["id": id, "password": password, "email": email]
         case let .loginWithFacebook(id, token):
             return ["fb_id": id, "fb_token": token]
         case let .loginWithApple(token):

--- a/SNUTT-2022/SNUTT/Services/AuthService.swift
+++ b/SNUTT-2022/SNUTT/Services/AuthService.swift
@@ -12,7 +12,7 @@ protocol AuthServiceProtocol {
     func loginWithId(id: String, password: String) async throws
     func loginWithApple(token: String) async throws
     func loginWithFacebook(id: String, token: String) async throws
-    func registerWithId(id: String, password: String, email: String?) async throws
+    func registerWithId(id: String, password: String, email: String) async throws
     func logout() async throws
 }
 
@@ -62,7 +62,7 @@ struct AuthService: AuthServiceProtocol, UserAuthHandler {
         try await registerFCMToken()
     }
 
-    func registerWithId(id: String, password: String, email: String?) async throws {
+    func registerWithId(id: String, password: String, email: String) async throws {
         let dto = try await authRepository.registerWithId(id: id, password: password, email: email)
         saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
@@ -114,6 +114,6 @@ class FakeAuthService: AuthServiceProtocol {
     func loginWithId(id _: String, password _: String) async throws {}
     func loginWithApple(token _: String) async throws {}
     func loginWithFacebook(id _: String, token _: String) async throws {}
-    func registerWithId(id _: String, password _: String, email _: String?) async throws {}
+    func registerWithId(id _: String, password _: String, email _: String) async throws {}
     func logout() async throws {}
 }

--- a/SNUTT-2022/SNUTT/ViewModels/OnboardViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/OnboardViewModel.swift
@@ -13,7 +13,7 @@ extension OnboardScene {
         func registerWith(id: String, password: String, email: String) async {
             // TODO: Validation
             do {
-                try await services.authService.registerWithId(id: id, password: password, email: email.isEmpty ? nil : email)
+                try await services.authService.registerWithId(id: id, password: password, email: email)
             } catch {
                 services.globalUIService.presentErrorAlert(error: error)
             }

--- a/SNUTT-2022/SNUTT/Views/Components/AnimatedTextField.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/AnimatedTextField.swift
@@ -33,6 +33,7 @@ struct AnimatedTextField: View {
             }
             .focused($_isFocused)
             .frame(height: 20)
+            .textInputAutocapitalization(.never)
 
             ZStack(alignment: .leading) {
                 Rectangle()

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/AccountSettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/AccountSettingScene.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct AccountSettingScene: View {
     @ObservedObject var viewModel: ViewModel
-    @State private var alertDisconnectFacebook: Bool = false
+    @State private var isDisconnectFBAlertPresented: Bool = false
+    @State private var isDeleteAccountAlertPresented: Bool = false
 
     var body: some View {
         List {
@@ -36,9 +37,9 @@ struct AccountSettingScene: View {
                 Section {
                     SettingsTextItem(title: "페이스북 이름", detail: facebookName)
                     SettingsButtonItem(title: "페이스북 연동 해제", role: .destructive) {
-                        alertDisconnectFacebook = true
+                        isDisconnectFBAlertPresented = true
                     }
-                    .alert("페이스북 연동 해제", isPresented: $alertDisconnectFacebook) {
+                    .alert("페이스북 연동 해제", isPresented: $isDisconnectFBAlertPresented) {
                         Button("취소", role: .cancel, action: {})
                         Button("해제", role: .destructive, action: {
                             Task {
@@ -62,9 +63,16 @@ struct AccountSettingScene: View {
             }
             Section {
                 SettingsButtonItem(title: "회원 탈퇴", role: .destructive) {
-                    Task {
-                        await viewModel.deleteUser()
+                    isDeleteAccountAlertPresented = true
+                }.alert("회원 탈퇴", isPresented: $isDeleteAccountAlertPresented) {
+                    Button("회원 탈퇴", role: .destructive) {
+                        Task {
+                            await viewModel.deleteUser()
+                        }
                     }
+                    Button("취소", role: .cancel) {}
+                } message: {
+                    Text("SNUTT 회원 탈퇴를 하시겠습니까?")
                 }
             }
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/SettingScene.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct SettingScene: View {
     let viewModel: SettingViewModel
+    
+    @State private var isLogoutAlertPresented: Bool = false
 
     var body: some View {
         List {
@@ -49,9 +51,14 @@ struct SettingScene: View {
 
             Section {
                 SettingsButtonItem(title: "로그아웃", role: .destructive) {
-                    Task {
-                        await viewModel.logout()
+                    isLogoutAlertPresented = true
+                }.alert("로그아웃 하시겠습니까?", isPresented: $isLogoutAlertPresented) {
+                    Button("로그아웃", role: .destructive) {
+                        Task {
+                            await viewModel.logout()
+                        }
                     }
+                    Button("취소", role: .cancel) {}
                 }
             }
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/SettingScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingScene: View {
     let viewModel: SettingViewModel
-    
+
     @State private var isLogoutAlertPresented: Bool = false
 
     var body: some View {

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/TimetableSettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/TimetableSettingScene.swift
@@ -16,39 +16,41 @@ struct TimetableSettingScene: View {
         Form {
             Section {
                 Toggle("자동 맞춤", isOn: $viewModel.timetableConfig.autoFit)
+                    .animation(.easeInOut, value: viewModel.timetableConfig.autoFit)
             }
-
-            Section(header: Text("시간표 범위 설정")) {
-                SettingsLinkItem(title: "요일", detail: viewModel.visibleWeekdaysPreview) {
-                    List {
-                        ForEach(Weekday.allCases) { weekday in
-                            Button {
-                                viewModel.toggleWeekday(weekday: weekday)
-                            } label: {
-                                HStack {
-                                    Text(weekday.symbol)
-                                    Spacer()
-                                    if viewModel.timetableConfig.visibleWeeks.contains(weekday) {
-                                        Image(systemName: "checkmark")
+            
+            if !viewModel.timetableConfig.autoFit {
+                Section(header: Text("시간표 범위 설정")) {
+                    SettingsLinkItem(title: "요일", detail: viewModel.visibleWeekdaysPreview) {
+                        List {
+                            ForEach(Weekday.allCases) { weekday in
+                                Button {
+                                    viewModel.toggleWeekday(weekday: weekday)
+                                } label: {
+                                    HStack {
+                                        Text(weekday.symbol)
+                                        Spacer()
+                                        if viewModel.timetableConfig.visibleWeeks.contains(weekday) {
+                                            Image(systemName: "checkmark")
+                                        }
                                     }
                                 }
                             }
                         }
+                        .navigationBarTitle("요일 선택")
                     }
-                    .navigationBarTitle("요일 선택")
+
+                    Group {
+                        DatePicker("시작",
+                                   selection: $viewModel.minHour,
+                                   in: viewModel.minTimeRange,
+                                   displayedComponents: [.hourAndMinute])
+                        DatePicker("종료",
+                                   selection: $viewModel.maxHour,
+                                   in: viewModel.maxTimeRange,
+                                   displayedComponents: [.hourAndMinute])
+                    }.datePickerStyle(.compact)
                 }
-
-                DatePicker("시작",
-                           selection: $viewModel.minHour,
-                           in: viewModel.minTimeRange,
-                           displayedComponents: [.hourAndMinute])
-                    .datePickerStyle(.compact)
-
-                DatePicker("종료",
-                           selection: $viewModel.maxHour,
-                           in: viewModel.maxTimeRange,
-                           displayedComponents: [.hourAndMinute])
-                    .datePickerStyle(.compact)
             }
 
             Section(header: Text("시간표 미리보기")) {

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/TimetableSettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/TimetableSettingScene.swift
@@ -18,7 +18,7 @@ struct TimetableSettingScene: View {
                 Toggle("자동 맞춤", isOn: $viewModel.timetableConfig.autoFit)
                     .animation(.easeInOut, value: viewModel.timetableConfig.autoFit)
             }
-            
+
             if !viewModel.timetableConfig.autoFit {
                 Section(header: Text("시간표 범위 설정")) {
                     SettingsLinkItem(title: "요일", detail: viewModel.visibleWeekdaysPreview) {

--- a/SNUTT-2022/SNUTT/Views/Scenes/SignUpView.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SignUpView.swift
@@ -22,7 +22,7 @@ struct SignUpView: View {
     @State private var email: String = ""
 
     var isButtonDisabled: Bool {
-        id.isEmpty || password.isEmpty || password2.isEmpty || password != password2
+        id.isEmpty || password.isEmpty || password2.isEmpty || email.isEmpty || password != password2
     }
 
     var body: some View {
@@ -31,9 +31,7 @@ struct SignUpView: View {
                 AnimatedTextField(label: "아이디", placeholder: "아이디를 입력하세요.", text: $id, shouldFocusOn: true)
                 AnimatedTextField(label: "비밀번호", placeholder: "비밀번호를 입력하세요.", text: $password, secure: true)
                 AnimatedTextField(label: "비밀번호 확인", placeholder: "비밀번호를 한번 더 입력하세요.", text: $password2, secure: true)
-                if displayMode == .register {
-                    AnimatedTextField(label: "이메일", placeholder: "(선택) 이메일 주소를 입력하세요.", text: $email)
-                }
+                AnimatedTextField(label: "이메일", placeholder: "이메일 주소를 입력하세요.", text: $email)
             }
 
             Spacer()


### PR DESCRIPTION
### 수정사항
- 로그아웃, 회원탈퇴 시 alert 추가
- (1) 회원가입 (2) 아이디/비밀번호 추가 -> 이 2가지 경우에서 이메일 필수 필드로 변경 ([관련 슬랙 스레드](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1668232280648599))
- 환경설정 > 시간표 설정에서 `자동맞춤`이 비활성화된 경우에만 시간표 범위 수정할 수 있도록 수정 (아래 영상 참고)


https://user-images.githubusercontent.com/70614553/203056968-c33f0dd2-eaf9-4840-bdfe-eca33ea09f91.mp4

