### PR TITLE
Auth 변수명 리팩토링

### DIFF
--- a/SNUTT-2022/SNUTT/Repositories/AuthRepository.swift
+++ b/SNUTT-2022/SNUTT/Repositories/AuthRepository.swift
@@ -9,10 +9,10 @@ import Alamofire
 import Foundation
 
 protocol AuthRepositoryProtocol {
-    func registerWithId(id: String, password: String, email: String) async throws -> LoginResponseDto
-    func loginWithApple(token: String) async throws -> LoginResponseDto
-    func loginWithFacebook(id: String, token: String) async throws -> LoginResponseDto
-    func loginWithId(id: String, password: String) async throws -> LoginResponseDto
+    func registerWithLocalId(localId: String, localPassword: String, email: String) async throws -> LoginResponseDto
+    func loginWithApple(appleToken: String) async throws -> LoginResponseDto
+    func loginWithFacebook(fbId: String, fbToken: String) async throws -> LoginResponseDto
+    func loginWithLocalId(localId: String, localPassword: String) async throws -> LoginResponseDto
     func logout(userId: String, fcmToken: String) async throws -> LogoutResponseDto
 }
 
@@ -23,30 +23,30 @@ class AuthRepository: AuthRepositoryProtocol {
         self.session = session
     }
 
-    func registerWithId(id: String, password: String, email: String) async throws -> LoginResponseDto {
+    func registerWithLocalId(localId: String, localPassword: String, email: String) async throws -> LoginResponseDto {
         return try await session
-            .request(AuthRouter.registerWithId(id: id, password: password, email: email))
+            .request(AuthRouter.registerWithLocalId(localId: localId, localPassword: localPassword, email: email))
             .serializingDecodable(LoginResponseDto.self)
             .handlingError()
     }
 
-    func loginWithApple(token: String) async throws -> LoginResponseDto {
+    func loginWithApple(appleToken: String) async throws -> LoginResponseDto {
         return try await session
-            .request(AuthRouter.loginWithApple(token: token))
+            .request(AuthRouter.loginWithApple(appleToken: appleToken))
             .serializingDecodable(LoginResponseDto.self)
             .handlingError()
     }
 
-    func loginWithFacebook(id: String, token: String) async throws -> LoginResponseDto {
+    func loginWithFacebook(fbId: String, fbToken: String) async throws -> LoginResponseDto {
         return try await session
-            .request(AuthRouter.loginWithFacebook(id: id, token: token))
+            .request(AuthRouter.loginWithFacebook(fbId: fbId, fbToken: fbToken))
             .serializingDecodable(LoginResponseDto.self)
             .handlingError()
     }
 
-    func loginWithId(id: String, password: String) async throws -> LoginResponseDto {
+    func loginWithLocalId(localId: String, localPassword: String) async throws -> LoginResponseDto {
         return try await session
-            .request(AuthRouter.loginWithId(id: id, password: password))
+            .request(AuthRouter.loginWithLocalId(localId: localId, localPassword: localPassword))
             .serializingDecodable(LoginResponseDto.self)
             .handlingError()
     }

--- a/SNUTT-2022/SNUTT/Repositories/Dto/AuthDto.swift
+++ b/SNUTT-2022/SNUTT/Repositories/Dto/AuthDto.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct LoginResponseDto: Codable {
     let token: String
-    let user_id: String
+    let user_id: String // server-side id of user entity
 }
 
 struct LogoutResponseDto: Codable {
@@ -17,7 +17,7 @@ struct LogoutResponseDto: Codable {
 }
 
 struct TokenResponseDto: Codable {
-    let token: String
+    let token: String // access token
 }
 
 struct DeviceResponseDto: Codable {

--- a/SNUTT-2022/SNUTT/Repositories/Router/AuthRouter.swift
+++ b/SNUTT-2022/SNUTT/Repositories/Router/AuthRouter.swift
@@ -13,17 +13,17 @@ enum AuthRouter: Router {
     var baseURL: URL { return URL(string: NetworkConfiguration.serverBaseURL + "/auth")! }
     static let shouldAddToken: Bool = false
 
-    case registerWithId(id: String, password: String, email: String)
-    case loginWithId(id: String, password: String)
-    case loginWithFacebook(id: String, token: String)
-    case loginWithApple(token: String)
+    case registerWithLocalId(localId: String, localPassword: String, email: String)
+    case loginWithLocalId(localId: String, localPassword: String)
+    case loginWithFacebook(fbId: String, fbToken: String)
+    case loginWithApple(appleToken: String)
     case logout(userId: String, fcmToken: String)
 
     var method: HTTPMethod {
         switch self {
-        case .loginWithId:
+        case .loginWithLocalId:
             return .post
-        case .registerWithId:
+        case .registerWithLocalId:
             return .post
         case .loginWithFacebook:
             return .post
@@ -36,9 +36,9 @@ enum AuthRouter: Router {
 
     var path: String {
         switch self {
-        case .loginWithId:
+        case .loginWithLocalId:
             return "/login_local"
-        case .registerWithId:
+        case .registerWithLocalId:
             return "/register_local"
         case .loginWithFacebook:
             return "/login_fb"
@@ -51,14 +51,14 @@ enum AuthRouter: Router {
 
     var parameters: [String: Any]? {
         switch self {
-        case let .loginWithId(id, password):
-            return ["id": id, "password": password]
-        case let .registerWithId(id, password, email):
-            return ["id": id, "password": password, "email": email]
-        case let .loginWithFacebook(id, token):
-            return ["fb_id": id, "fb_token": token]
-        case let .loginWithApple(token):
-            return ["apple_token": token]
+        case let .loginWithLocalId(localId, localPassword):
+            return ["id": localId, "password": localPassword]
+        case let .registerWithLocalId(localId, localPassword, email):
+            return ["id": localId, "password": localPassword, "email": email]
+        case let .loginWithFacebook(fbId, fbToken):
+            return ["fb_id": fbId, "fb_token": fbToken]
+        case let .loginWithApple(appleToken):
+            return ["apple_token": appleToken]
         case let .logout(userId, fcmToken):
             return ["user_id": userId, "registration_id": fcmToken]
         }

--- a/SNUTT-2022/SNUTT/Repositories/Router/UserRouter.swift
+++ b/SNUTT-2022/SNUTT/Repositories/Router/UserRouter.swift
@@ -16,8 +16,8 @@ enum UserRouter: Router {
     case getUser
     case editUser(email: String)
     case changePassword(oldPassword: String, newPassword: String)
-    case addLocalId(id: String, password: String)
-    case connectFacebook(id: String, token: String)
+    case addLocalId(localId: String, localPassword: String)
+    case connectFacebook(fbId: String, fbToken: String)
     case disconnectFacebook
     case getFB
     case addDevice(fcmToken: String)
@@ -74,10 +74,10 @@ enum UserRouter: Router {
             return ["email": email]
         case let .changePassword(oldPassword, newPassword):
             return ["old_password": oldPassword, "new_password": newPassword]
-        case let .addLocalId(id, password):
-            return ["id": id, "password": password]
-        case let .connectFacebook(id, token):
-            return ["fb_id": id, "fb_token": token]
+        case let .addLocalId(localId, localPasword):
+            return ["id": localId, "password": localPasword]
+        case let .connectFacebook(fbId, fbToken):
+            return ["fb_id": fbId, "fb_token": fbToken]
         case .disconnectFacebook:
             return nil
         case .getFB:

--- a/SNUTT-2022/SNUTT/Repositories/UserDefaultsRepository.swift
+++ b/SNUTT-2022/SNUTT/Repositories/UserDefaultsRepository.swift
@@ -14,7 +14,7 @@ protocol UserDefaultsRepositoryProtocol {
 }
 
 enum STDefaultsKey: String {
-    case token
+    case accessToken
     case apiKey
     case userId
     case userDto

--- a/SNUTT-2022/SNUTT/Repositories/UserRepository.swift
+++ b/SNUTT-2022/SNUTT/Repositories/UserRepository.swift
@@ -13,7 +13,7 @@ protocol UserRepositoryProtocol {
     func connectFacebook(fbId: String, fbToken: String) async throws -> TokenResponseDto
     func disconnectFacebook() async throws -> TokenResponseDto
     func changePassword(from oldPassword: String, to newPassword: String) async throws -> TokenResponseDto
-    func addLocalId(id: String, password: String) async throws -> TokenResponseDto
+    func addLocalId(localId: String, localPassword: String) async throws -> TokenResponseDto
     func deleteUser() async throws
     func addDevice(fcmToken: String) async throws -> DeviceResponseDto
     func deleteDevice(fcmToken: String) async throws -> DeviceResponseDto
@@ -35,7 +35,7 @@ class UserRepository: UserRepositoryProtocol {
 
     func connectFacebook(fbId: String, fbToken: String) async throws -> TokenResponseDto {
         return try await session
-            .request(UserRouter.connectFacebook(id: fbId, token: fbToken))
+            .request(UserRouter.connectFacebook(fbId: fbId, fbToken: fbToken))
             .serializingDecodable(TokenResponseDto.self)
             .handlingError()
     }
@@ -54,9 +54,9 @@ class UserRepository: UserRepositoryProtocol {
             .handlingError()
     }
 
-    func addLocalId(id: String, password: String) async throws -> TokenResponseDto {
+    func addLocalId(localId: String, localPassword: String) async throws -> TokenResponseDto {
         return try await session
-            .request(UserRouter.addLocalId(id: id, password: password))
+            .request(UserRouter.addLocalId(localId: localId, localPassword: localPassword))
             .serializingDecodable(TokenResponseDto.self)
             .handlingError()
     }

--- a/SNUTT-2022/SNUTT/Services/AuthService.swift
+++ b/SNUTT-2022/SNUTT/Services/AuthService.swift
@@ -9,10 +9,10 @@ import Foundation
 
 protocol AuthServiceProtocol {
     func loadAccessTokenDuringBootstrap()
-    func loginWithId(id: String, password: String) async throws
-    func loginWithApple(token: String) async throws
-    func loginWithFacebook(id: String, token: String) async throws
-    func registerWithId(id: String, password: String, email: String) async throws
+    func loginWithLocalId(localId: String, localPassword: String) async throws
+    func loginWithApple(appleToken: String) async throws
+    func loginWithFacebook(fbId: String, fbToken: String) async throws
+    func registerWithLocalId(localId: String, localPassword: String, email: String) async throws
     func logout() async throws
 }
 
@@ -38,7 +38,7 @@ struct AuthService: AuthServiceProtocol, UserAuthHandler {
             appState.user.accessToken = dto.token
             appState.user.userId = dto.user_id
         }
-        userDefaultsRepository.set(String.self, key: .token, value: dto.token)
+        userDefaultsRepository.set(String.self, key: .accessToken, value: dto.token)
         userDefaultsRepository.set(String.self, key: .userId, value: dto.user_id)
     }
 
@@ -49,33 +49,33 @@ struct AuthService: AuthServiceProtocol, UserAuthHandler {
 
     func loadAccessTokenDuringBootstrap() {
         /// **DO NOT RUN THIS CODE ASYNCHRONOUSLY**. We need to show splash screen until the loading finishes.
-        appState.user.accessToken = userDefaultsRepository.get(String.self, key: .token)
+        appState.user.accessToken = userDefaultsRepository.get(String.self, key: .accessToken)
         appState.user.userId = userDefaultsRepository.get(String.self, key: .userId)
         if let userDto = userDefaultsRepository.get(UserDto.self, key: .userDto) {
             appState.user.current = User(from: userDto)
         }
     }
 
-    func loginWithId(id: String, password: String) async throws {
-        let dto = try await authRepository.loginWithId(id: id, password: password)
+    func loginWithLocalId(localId: String, localPassword: String) async throws {
+        let dto = try await authRepository.loginWithLocalId(localId: localId, localPassword: localPassword)
         saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
 
-    func registerWithId(id: String, password: String, email: String) async throws {
-        let dto = try await authRepository.registerWithId(id: id, password: password, email: email)
+    func registerWithLocalId(localId: String, localPassword: String, email: String) async throws {
+        let dto = try await authRepository.registerWithLocalId(localId: localId, localPassword: localPassword, email: email)
         saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
 
-    func loginWithApple(token: String) async throws {
-        let dto = try await authRepository.loginWithApple(token: token)
+    func loginWithApple(appleToken: String) async throws {
+        let dto = try await authRepository.loginWithApple(appleToken: appleToken)
         saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
 
-    func loginWithFacebook(id: String, token: String) async throws {
-        let dto = try await authRepository.loginWithFacebook(id: id, token: token)
+    func loginWithFacebook(fbId: String, fbToken: String) async throws {
+        let dto = try await authRepository.loginWithFacebook(fbId: fbId, fbToken: fbToken)
         saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
@@ -102,7 +102,7 @@ extension UserAuthHandler {
             appState.user.userId = nil
             appState.user.current = nil
         }
-        localRepositories.userDefaultsRepository.set(String.self, key: .token, value: nil)
+        localRepositories.userDefaultsRepository.set(String.self, key: .accessToken, value: nil)
         localRepositories.userDefaultsRepository.set(String.self, key: .userId, value: nil)
         localRepositories.userDefaultsRepository.set(UserDto.self, key: .userDto, value: nil)
         localRepositories.userDefaultsRepository.set(String.self, key: .fcmToken, value: nil)
@@ -111,9 +111,9 @@ extension UserAuthHandler {
 
 class FakeAuthService: AuthServiceProtocol {
     func loadAccessTokenDuringBootstrap() {}
-    func loginWithId(id _: String, password _: String) async throws {}
-    func loginWithApple(token _: String) async throws {}
-    func loginWithFacebook(id _: String, token _: String) async throws {}
-    func registerWithId(id _: String, password _: String, email _: String) async throws {}
+    func loginWithLocalId(localId _: String, localPassword _: String) async throws {}
+    func loginWithApple(appleToken _: String) async throws {}
+    func loginWithFacebook(fbId _: String, fbToken _: String) async throws {}
+    func registerWithLocalId(localId _: String, localPassword _: String, email _: String) async throws {}
     func logout() async throws {}
 }

--- a/SNUTT-2022/SNUTT/Services/UserService.swift
+++ b/SNUTT-2022/SNUTT/Services/UserService.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol UserServiceProtocol {
     func fetchUser() async throws
     func deleteUser() async throws
-    func addLocalId(id: String, password: String) async throws
+    func addLocalId(localId: String, localPassword: String) async throws
     func changePassword(from oldPassword: String, to newPassword: String) async throws
     func disconnectFacebook() async throws
     func connectFacebook(fbId: String, fbToken: String) async throws
@@ -42,8 +42,8 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
         try await updateToken(from: dto)
     }
 
-    func addLocalId(id: String, password: String) async throws {
-        let dto = try await userRepository.addLocalId(id: id, password: password)
+    func addLocalId(localId: String, localPassword: String) async throws {
+        let dto = try await userRepository.addLocalId(localId: localId, localPassword: localPassword)
         try await updateToken(from: dto)
     }
 
@@ -70,7 +70,7 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
             return
         }
 
-        try await userRepository.addDevice(fcmToken: fcmToken)
+        let _ = try await userRepository.addDevice(fcmToken: fcmToken)
     }
 
     func deleteDevice(fcmToken: String) async throws {
@@ -80,14 +80,14 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
             return
         }
 
-        try await userRepository.deleteDevice(fcmToken: fcmToken)
+        let _ = try await userRepository.deleteDevice(fcmToken: fcmToken)
     }
 
     private func updateToken(from dto: TokenResponseDto) async throws {
         DispatchQueue.main.async {
             appState.user.accessToken = dto.token
         }
-        userDefaultsRepository.set(String.self, key: .token, value: dto.token)
+        userDefaultsRepository.set(String.self, key: .accessToken, value: dto.token)
         try await fetchUser()
     }
 
@@ -102,7 +102,7 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
 class FakeUserService: UserServiceProtocol {
     func fetchUser() {}
     func deleteUser() async throws {}
-    func addLocalId(id _: String, password _: String) async throws {}
+    func addLocalId(localId _: String, localPassword _: String) async throws {}
     func changePassword(from _: String, to _: String) async throws {}
     func disconnectFacebook() async throws {}
     func connectFacebook(fbId _: String, fbToken _: String) async throws {}

--- a/SNUTT-2022/SNUTT/ViewModels/AccountSettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/AccountSettingViewModel.swift
@@ -34,9 +34,9 @@ extension AccountSettingScene {
             }
         }
 
-        func attachLocalId(id: String, password: String) async {
+        func attachLocalId(localId: String, localPassword: String) async {
             do {
-                try await services.userService.addLocalId(id: id, password: password)
+                try await services.userService.addLocalId(localId: localId, localPassword: localPassword)
             } catch {
                 services.globalUIService.presentErrorAlert(error: error)
             }

--- a/SNUTT-2022/SNUTT/ViewModels/OnboardViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/OnboardViewModel.swift
@@ -13,7 +13,7 @@ extension OnboardScene {
         func registerWith(id: String, password: String, email: String) async {
             // TODO: Validation
             do {
-                try await services.authService.registerWithId(id: id, password: password, email: email)
+                try await services.authService.registerWithLocalId(localId: id, localPassword: password, email: email)
             } catch {
                 services.globalUIService.presentErrorAlert(error: error)
             }
@@ -24,7 +24,7 @@ extension OnboardScene {
 extension OnboardScene.ViewModel: FacebookLoginProtocol {
     func handleFacebookToken(fbId: String, fbToken: String) async {
         do {
-            try await services.authService.loginWithFacebook(id: fbId, token: fbToken)
+            try await services.authService.loginWithFacebook(fbId: fbId, fbToken: fbToken)
         } catch {
             services.globalUIService.presentErrorAlert(error: error)
         }
@@ -62,7 +62,7 @@ extension OnboardScene.ViewModel: ASAuthorizationControllerDelegate {
             return
         }
         do {
-            try await services.authService.loginWithApple(token: token)
+            try await services.authService.loginWithApple(appleToken: token)
         } catch {
             services.globalUIService.presentErrorAlert(error: error)
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
@@ -10,25 +10,25 @@ import SwiftUI
 struct LoginScene: View {
     @ObservedObject var viewModel: ViewModel
 
-    @State private var id: String = ""
-    @State private var password: String = ""
+    @State private var localId: String = ""
+    @State private var localPassword: String = ""
 
     var isButtonDisabled: Bool {
-        id.isEmpty || password.isEmpty
+        localId.isEmpty || localPassword.isEmpty
     }
 
     var body: some View {
         VStack {
             VStack(spacing: 15) {
-                AnimatedTextField(label: "아이디", placeholder: "아이디를 입력하세요.", text: $id, shouldFocusOn: true)
-                AnimatedTextField(label: "비밀번호", placeholder: "비밀번호를 입력하세요.", text: $password, secure: true)
+                AnimatedTextField(label: "아이디", placeholder: "아이디를 입력하세요.", text: $localId, shouldFocusOn: true)
+                AnimatedTextField(label: "비밀번호", placeholder: "비밀번호를 입력하세요.", text: $localPassword, secure: true)
             }
 
             Spacer()
 
             Button {
                 Task {
-                    await viewModel.loginWithId(id: id, password: password)
+                    await viewModel.loginWithLocalId(localId: localId, localPassword: localPassword)
                     resignFirstResponder()
                 }
             } label: {
@@ -50,9 +50,9 @@ struct LoginScene: View {
 
 extension LoginScene {
     class ViewModel: BaseViewModel, ObservableObject {
-        func loginWithId(id: String, password: String) async {
+        func loginWithLocalId(localId: String, localPassword: String) async {
             do {
-                try await services.authService.loginWithId(id: id, password: password)
+                try await services.authService.loginWithLocalId(localId: localId, localPassword: localPassword)
             } catch {
                 services.globalUIService.presentErrorAlert(error: error)
             }

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/AccountSettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/AccountSettingScene.swift
@@ -14,9 +14,9 @@ struct AccountSettingScene: View {
 
     var body: some View {
         List {
-            if let username = viewModel.currentUser?.localId {
+            if let localId = viewModel.currentUser?.localId {
                 Section {
-                    SettingsTextItem(title: "아이디", detail: username)
+                    SettingsTextItem(title: "아이디", detail: localId)
                     SettingsLinkItem(title: "비밀번호 변경") {
                         ChangePasswordView { old, new in
                             await viewModel.changePassword(from: old, to: new)
@@ -26,8 +26,8 @@ struct AccountSettingScene: View {
             } else {
                 Section {
                     SettingsLinkItem(title: "아이디 / 비밀번호 추가") {
-                        SignUpView(displayMode: .attach) { id, password, _ in
-                            await viewModel.attachLocalId(id: id, password: password)
+                        SignUpView(displayMode: .attach) { localId, localPassword, _ in
+                            await viewModel.attachLocalId(localId: localId, localPassword: localPassword)
                         }
                     }
                 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/SignUpView.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SignUpView.swift
@@ -74,8 +74,8 @@ struct SignUpView: View {
     struct SignUpScene_Previews: PreviewProvider {
         static var previews: some View {
             NavigationView {
-                SignUpView { id, password, email in
-                    print(id, password, email)
+                SignUpView { localId, localPassword, email in
+                    print(localId, localPassword, email)
                 }
             }
         }

--- a/SNUTT-2022/SNUTTTests/AuthRepositoryTests.swift
+++ b/SNUTT-2022/SNUTTTests/AuthRepositoryTests.swift
@@ -17,7 +17,7 @@ class AuthRepositoryTests: XCTestCase {
 
     func testRegisterAndLoginWithId() async throws {
         do {
-            let _ = try await repository.registerWithId(id: testId, password: testPW, email: "")
+            let _ = try await repository.registerWithLocalId(localId: testId, localPassword: testPW, email: "")
         } catch {
             if error.asSTError?.code == .DUPLICATE_ID {
                 // 중복 발생 가능
@@ -27,13 +27,13 @@ class AuthRepositoryTests: XCTestCase {
         }
 
         do {
-            let _ = try await repository.registerWithId(id: testId, password: testPW, email: "")
+            let _ = try await repository.registerWithLocalId(localId: testId, localPassword: testPW, email: "")
         } catch {
             XCTAssertEqual(error.asSTError?.code, .DUPLICATE_ID)
         }
 
         do {
-            let _ = try await repository.loginWithId(id: testId, password: testPW)
+            let _ = try await repository.loginWithLocalId(localId: testId, localPassword: testPW)
         } catch {
             XCTFail(error.asSTError?.title ?? "")
         }


### PR DESCRIPTION
- `id`, `token`, `userId` 등 하나의 변수가 맥락에 따라 다른 의미를 가지는 경우가 있어서, 각 변수명이 좀 더 분명한 의도를 갖도록 수정했습니다.
- 바뀐 변수명은 아래와 같습니다.
    - `id` -> `localId`, `fbId`
    - `token` -> `appleToken`, `fbToken`, `accessToken`
    - `userId` -> `userId` (이것은 유저 entity의 primary key 필드를 의미하는데, 마땅한 다른 이름이 생각나지 않아 유지했습니다)
