### PR TITLE
Use `MainActor` where applicable

### DIFF
--- a/SNUTT-2022/SNUTT/Extensions/FacebookLogin.swift
+++ b/SNUTT-2022/SNUTT/Extensions/FacebookLogin.swift
@@ -17,12 +17,16 @@ extension FacebookLoginProtocol {
         LoginManager().logIn(permissions: [Permission.publicProfile.name], from: nil) { result, error in
 
             if error != nil {
-                self.services.globalUIService.presentErrorAlert(error: .NO_FB_ID_OR_TOKEN)
+                Task {
+                    await self.services.globalUIService.presentErrorAlert(error: .NO_FB_ID_OR_TOKEN)
+                }
                 return
             }
 
             guard let result = result else {
-                self.services.globalUIService.presentErrorAlert(error: .NO_FB_ID_OR_TOKEN)
+                Task {
+                    await self.services.globalUIService.presentErrorAlert(error: .NO_FB_ID_OR_TOKEN)
+                }
                 return
             }
 
@@ -33,7 +37,9 @@ extension FacebookLoginProtocol {
             guard let fbUserId = result.token?.userID,
                   let fbToken = result.token?.tokenString
             else {
-                self.services.globalUIService.presentErrorAlert(error: .NO_FB_ID_OR_TOKEN)
+                Task {
+                    await self.services.globalUIService.presentErrorAlert(error: .NO_FB_ID_OR_TOKEN)
+                }
                 return
             }
 

--- a/SNUTT-2022/SNUTT/Services/AuthService.swift
+++ b/SNUTT-2022/SNUTT/Services/AuthService.swift
@@ -56,25 +56,25 @@ struct AuthService: AuthServiceProtocol, UserAuthHandler {
 
     func loginWithLocalId(localId: String, localPassword: String) async throws {
         let dto = try await authRepository.loginWithLocalId(localId: localId, localPassword: localPassword)
-        saveAccessTokenFromLoginResponse(dto: dto)
+        await saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
 
     func registerWithLocalId(localId: String, localPassword: String, email: String) async throws {
         let dto = try await authRepository.registerWithLocalId(localId: localId, localPassword: localPassword, email: email)
-        saveAccessTokenFromLoginResponse(dto: dto)
+        await saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
 
     func loginWithApple(appleToken: String) async throws {
         let dto = try await authRepository.loginWithApple(appleToken: appleToken)
-        saveAccessTokenFromLoginResponse(dto: dto)
+        await saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
 
     func loginWithFacebook(fbId: String, fbToken: String) async throws {
         let dto = try await authRepository.loginWithFacebook(fbId: fbId, fbToken: fbToken)
-        saveAccessTokenFromLoginResponse(dto: dto)
+        await saveAccessTokenFromLoginResponse(dto: dto)
         try await registerFCMToken()
     }
 

--- a/SNUTT-2022/SNUTT/Services/AuthService.swift
+++ b/SNUTT-2022/SNUTT/Services/AuthService.swift
@@ -33,7 +33,7 @@ struct AuthService: AuthServiceProtocol, UserAuthHandler {
         localRepositories.userDefaultsRepository
     }
 
-    @MainActor private func saveAccessTokenFromLoginResponse(dto: LoginResponseDto) {
+    @MainActor private func saveAccessTokenFromLoginResponse(dto: LoginResponseDto) async {
         appState.user.accessToken = dto.token
         appState.user.userId = dto.user_id
         userDefaultsRepository.set(String.self, key: .token, value: dto.token)
@@ -90,11 +90,11 @@ struct AuthService: AuthServiceProtocol, UserAuthHandler {
 protocol UserAuthHandler {
     var appState: AppState { get set }
     var localRepositories: AppEnvironment.LocalRepositories { get set }
-    func clearUserInfo()
+    func clearUserInfo() async
 }
 
 extension UserAuthHandler {
-    @MainActor func clearUserInfo() {
+    @MainActor func clearUserInfo() async {
         appState.user.accessToken = nil
         appState.user.userId = nil
         appState.user.current = nil

--- a/SNUTT-2022/SNUTT/Services/CourseBookService.swift
+++ b/SNUTT-2022/SNUTT/Services/CourseBookService.swift
@@ -28,7 +28,7 @@ struct CourseBookService: CourseBookServiceProtocol {
     func fetchCourseBookList() async throws {
         let dtos = try await courseBookRepository.fetchAllCourseBookList()
         let quarters = dtos.map { Quarter(from: $0) }
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.courseBookList = quarters
         }
     }

--- a/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
+++ b/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
@@ -41,7 +41,7 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
         appState.menu.isOpen = value
     }
 
-    @MainActor func openEllipsis(for timetable: TimetableMetadata) async  {
+    @MainActor func openEllipsis(for timetable: TimetableMetadata) async {
         appState.menu.isEllipsisSheetOpen = true
         appState.menu.ellipsisTarget = timetable
     }

--- a/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
+++ b/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
@@ -8,95 +8,95 @@
 import Foundation
 
 protocol GlobalUIServiceProtocol {
-    func setIsMenuOpen(_ value: Bool)
+    func setIsMenuOpen(_ value: Bool) async
 
-    func openEllipsis(for timetable: TimetableMetadata)
-    func closeEllipsis()
+    func openEllipsis(for timetable: TimetableMetadata) async
+    func closeEllipsis() async
 
-    func openThemeSheet()
-    func closeThemeSheet()
+    func openThemeSheet() async
+    func closeThemeSheet() async
 
-    func openRenameSheet()
-    func closeRenameSheet()
+    func openRenameSheet() async
+    func closeRenameSheet() async
 
-    func openCreateSheet(withPicker: Bool)
-    func closeCreateSheet()
+    func openCreateSheet(withPicker: Bool) async
+    func closeCreateSheet() async
 
-    func setRenameTitle(_ value: String)
-    func setCreateTitle(_ value: String)
-    func setCreateQuarter(_ value: Quarter?)
+    func setRenameTitle(_ value: String) async
+    func setCreateTitle(_ value: String) async
+    func setCreateQuarter(_ value: Quarter?) async
 
-    func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?)
+    func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?) async
 
-    func presentErrorAlert(error: STError?)
-    func presentErrorAlert(error: ErrorCode)
-    func presentErrorAlert(error: Error)
+    func presentErrorAlert(error: STError?) async
+    func presentErrorAlert(error: ErrorCode) async
+    func presentErrorAlert(error: Error) async
 }
 
 struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
     var appState: AppState
     var localRepositories: AppEnvironment.LocalRepositories
 
-    @MainActor func setIsMenuOpen(_ value: Bool) {
+    @MainActor func setIsMenuOpen(_ value: Bool) async {
         appState.menu.isOpen = value
     }
 
-    @MainActor func openEllipsis(for timetable: TimetableMetadata) {
+    @MainActor func openEllipsis(for timetable: TimetableMetadata) async  {
         appState.menu.isEllipsisSheetOpen = true
         appState.menu.ellipsisTarget = timetable
     }
 
-    @MainActor func closeEllipsis() {
+    @MainActor func closeEllipsis() async {
         appState.menu.isEllipsisSheetOpen = false
         appState.menu.ellipsisTarget = nil
     }
 
-    @MainActor func openThemeSheet() {
+    @MainActor func openThemeSheet() async {
         appState.menu.isOpen = false
         appState.menu.isEllipsisSheetOpen = false
         appState.menu.isThemeSheetOpen = true
     }
 
-    @MainActor func closeThemeSheet() {
+    @MainActor func closeThemeSheet() async {
         appState.menu.isThemeSheetOpen = false
         appState.timetable.current?.selectedTheme = nil
     }
 
-    @MainActor func openRenameSheet() {
+    @MainActor func openRenameSheet() async {
         appState.menu.renameTitle = appState.menu.ellipsisTarget?.title ?? ""
         appState.menu.isEllipsisSheetOpen = false
         appState.menu.isRenameSheetOpen = true
     }
 
-    @MainActor func closeRenameSheet() {
+    @MainActor func closeRenameSheet() async {
         appState.menu.isRenameSheetOpen = false
     }
 
-    @MainActor func openCreateSheet(withPicker: Bool) {
+    @MainActor func openCreateSheet(withPicker: Bool) async {
         appState.menu.createTitle = ""
         appState.menu.createQuarter = withPicker ? appState.timetable.courseBookList?.first : nil
         appState.menu.isCreateSheetOpen = true
     }
 
-    @MainActor func closeCreateSheet() {
+    @MainActor func closeCreateSheet() async {
         appState.menu.isCreateSheetOpen = false
     }
 
-    @MainActor func setRenameTitle(_ value: String) {
+    @MainActor func setRenameTitle(_ value: String) async {
         appState.menu.renameTitle = value
     }
 
-    @MainActor func setCreateTitle(_ value: String) {
+    @MainActor func setCreateTitle(_ value: String) async {
         appState.menu.createTitle = value
     }
 
-    @MainActor func setCreateQuarter(_ value: Quarter?) {
+    @MainActor func setCreateQuarter(_ value: Quarter?) async {
         appState.menu.createQuarter = value
     }
 
     // MARK: Lecture Time Sheet
 
-    @MainActor func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?) {
+    @MainActor func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?) async {
         appState.menu.timePlaceToModify = timePlace
         appState.menu.lectureTimeSheetAction = action
         appState.menu.isLectureTimeSheetOpen = value
@@ -104,22 +104,22 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
 
     // MARK: Error Handling
 
-    @MainActor func presentErrorAlert(error: Error) {
-        presentErrorAlert(error: error.asSTError)
+    @MainActor func presentErrorAlert(error: Error) async {
+        await presentErrorAlert(error: error.asSTError)
     }
 
-    @MainActor func presentErrorAlert(error: ErrorCode) {
-        presentErrorAlert(error: .init(error))
+    @MainActor func presentErrorAlert(error: ErrorCode) async {
+        await presentErrorAlert(error: .init(error))
     }
 
-    @MainActor func presentErrorAlert(error: STError?) {
+    @MainActor func presentErrorAlert(error: STError?) async {
         guard let error = error else {
             appState.system.isErrorAlertPresented = false
             return
         }
 
         if error.code == .WRONG_USER_TOKEN || error.code == .NO_USER_TOKEN {
-            clearUserInfo()
+            await clearUserInfo()
         }
 
         appState.system.error = error

--- a/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
+++ b/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
@@ -37,108 +37,82 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
     var appState: AppState
     var localRepositories: AppEnvironment.LocalRepositories
 
-    func setIsMenuOpen(_ value: Bool) {
-        DispatchQueue.main.async {
-            appState.menu.isOpen = value
-        }
+    @MainActor func setIsMenuOpen(_ value: Bool) {
+        appState.menu.isOpen = value
     }
 
-    func openEllipsis(for timetable: TimetableMetadata) {
-        DispatchQueue.main.async {
-            appState.menu.isEllipsisSheetOpen = true
-            appState.menu.ellipsisTarget = timetable
-        }
+    @MainActor func openEllipsis(for timetable: TimetableMetadata) {
+        appState.menu.isEllipsisSheetOpen = true
+        appState.menu.ellipsisTarget = timetable
     }
 
-    func closeEllipsis() {
-        DispatchQueue.main.async {
-            appState.menu.isEllipsisSheetOpen = false
-            appState.menu.ellipsisTarget = nil
-        }
+    @MainActor func closeEllipsis() {
+        appState.menu.isEllipsisSheetOpen = false
+        appState.menu.ellipsisTarget = nil
     }
 
-    func openThemeSheet() {
-        DispatchQueue.main.async {
-            appState.menu.isOpen = false
-            appState.menu.isEllipsisSheetOpen = false
-            appState.menu.isThemeSheetOpen = true
-        }
+    @MainActor func openThemeSheet() {
+        appState.menu.isOpen = false
+        appState.menu.isEllipsisSheetOpen = false
+        appState.menu.isThemeSheetOpen = true
     }
 
-    func closeThemeSheet() {
-        DispatchQueue.main.async {
-            appState.menu.isThemeSheetOpen = false
-            appState.timetable.current?.selectedTheme = nil
-        }
+    @MainActor func closeThemeSheet() {
+        appState.menu.isThemeSheetOpen = false
+        appState.timetable.current?.selectedTheme = nil
     }
 
-    func openRenameSheet() {
-        DispatchQueue.main.async {
-            appState.menu.renameTitle = appState.menu.ellipsisTarget?.title ?? ""
-            appState.menu.isEllipsisSheetOpen = false
-            appState.menu.isRenameSheetOpen = true
-        }
+    @MainActor func openRenameSheet() {
+        appState.menu.renameTitle = appState.menu.ellipsisTarget?.title ?? ""
+        appState.menu.isEllipsisSheetOpen = false
+        appState.menu.isRenameSheetOpen = true
     }
 
-    func closeRenameSheet() {
-        DispatchQueue.main.async {
-            appState.menu.isRenameSheetOpen = false
-        }
+    @MainActor func closeRenameSheet() {
+        appState.menu.isRenameSheetOpen = false
     }
 
-    func openCreateSheet(withPicker: Bool) {
-        DispatchQueue.main.async {
-            appState.menu.createTitle = ""
-            appState.menu.createQuarter = withPicker ? appState.timetable.courseBookList?.first : nil
-            appState.menu.isCreateSheetOpen = true
-        }
+    @MainActor func openCreateSheet(withPicker: Bool) {
+        appState.menu.createTitle = ""
+        appState.menu.createQuarter = withPicker ? appState.timetable.courseBookList?.first : nil
+        appState.menu.isCreateSheetOpen = true
     }
 
-    func closeCreateSheet() {
-        DispatchQueue.main.async {
-            appState.menu.isCreateSheetOpen = false
-        }
+    @MainActor func closeCreateSheet() {
+        appState.menu.isCreateSheetOpen = false
     }
 
-    func setRenameTitle(_ value: String) {
-        DispatchQueue.main.async {
-            appState.menu.renameTitle = value
-        }
+    @MainActor func setRenameTitle(_ value: String) {
+        appState.menu.renameTitle = value
     }
 
-    func setCreateTitle(_ value: String) {
-        DispatchQueue.main.async {
-            appState.menu.createTitle = value
-        }
+    @MainActor func setCreateTitle(_ value: String) {
+        appState.menu.createTitle = value
     }
 
-    func setCreateQuarter(_ value: Quarter?) {
-        DispatchQueue.main.async {
-            appState.menu.createQuarter = value
-        }
+    @MainActor func setCreateQuarter(_ value: Quarter?) {
+        appState.menu.createQuarter = value
     }
 
     // MARK: Lecture Time Sheet
 
-    func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?) {
-        DispatchQueue.main.async {
-            appState.menu.timePlaceToModify = timePlace
-            appState.menu.lectureTimeSheetAction = action
-            appState.menu.isLectureTimeSheetOpen = value
-        }
+    @MainActor func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?) {
+        appState.menu.timePlaceToModify = timePlace
+        appState.menu.lectureTimeSheetAction = action
+        appState.menu.isLectureTimeSheetOpen = value
     }
 
     // MARK: Error Handling
 
-    func presentErrorAlert(error: Error) {
+    @MainActor func presentErrorAlert(error: Error) {
         presentErrorAlert(error: error.asSTError)
     }
 
-    func presentErrorAlert(error: ErrorCode) {
+    @MainActor func presentErrorAlert(error: ErrorCode) {
         presentErrorAlert(error: .init(error))
     }
 
-    func presentErrorAlert(error: STError?) {
+    @MainActor func presentErrorAlert(error: STError?) {
         guard let error = error else {
             appState.system.isErrorAlertPresented = false
             return
@@ -148,9 +122,7 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
             clearUserInfo()
         }
 
-        DispatchQueue.main.async {
-            appState.system.error = error
-            appState.system.isErrorAlertPresented = true
-        }
+        appState.system.error = error
+        appState.system.isErrorAlertPresented = true
     }
 }

--- a/SNUTT-2022/SNUTT/Services/LectureService.swift
+++ b/SNUTT-2022/SNUTT/Services/LectureService.swift
@@ -40,7 +40,7 @@ struct LectureService: LectureServiceProtocol {
         guard let currentTimetable = appState.timetable.current else { return }
         let dto = try await lectureRepository.addLecture(timetableId: currentTimetable.id, lectureId: lecture.id, isForced: isForced)
         let timetable = Timetable(from: dto)
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.current = timetable
             appState.search.selectedLecture = nil
         }
@@ -53,7 +53,7 @@ struct LectureService: LectureServiceProtocol {
         lectureDto.class_time_mask = nil
         let dto = try await lectureRepository.addCustomLecture(timetableId: currentTimetable.id, lecture: lectureDto, isForced: isForced)
         let timetable = Timetable(from: dto)
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.current = timetable
         }
         userDefaultsRepository.set(TimetableDto.self, key: .currentTimetable, value: dto)
@@ -73,7 +73,7 @@ struct LectureService: LectureServiceProtocol {
 
         let dto = try await lectureRepository.updateLecture(timetableId: currentTimetable.id, oldLecture: .init(from: oldLecture), newLecture: .init(from: newLecture), isForced: isForced)
         let timetable = Timetable(from: dto)
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.current = timetable
         }
         userDefaultsRepository.set(TimetableDto.self, key: .currentTimetable, value: dto)
@@ -83,7 +83,7 @@ struct LectureService: LectureServiceProtocol {
         guard let currentTimetable = appState.timetable.current else { return }
         let dto = try await lectureRepository.deleteLecture(timetableId: currentTimetable.id, lectureId: lecture.id)
         let timetable = Timetable(from: dto)
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.current = timetable
         }
         userDefaultsRepository.set(TimetableDto.self, key: .currentTimetable, value: dto)
@@ -93,7 +93,7 @@ struct LectureService: LectureServiceProtocol {
         guard let currentTimetable = appState.timetable.current else { return }
         let dto = try await lectureRepository.resetLecture(timetableId: currentTimetable.id, lectureId: lecture.id)
         let timetable = Timetable(from: dto)
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.current = timetable
         }
         userDefaultsRepository.set(TimetableDto.self, key: .currentTimetable, value: dto)

--- a/SNUTT-2022/SNUTT/Services/PopupService.swift
+++ b/SNUTT-2022/SNUTT/Services/PopupService.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 protocol PopupServiceProtocol {
     func getRecentPopupList() async throws
-    func saveLastUpdate(popup: Popup)
+    func saveLastUpdate(popup: Popup) async
     func showNextPopup()
 }
 
@@ -49,7 +49,7 @@ struct PopupService: PopupServiceProtocol {
         }
     }
 
-    @MainActor func saveLastUpdate(popup: Popup) {
+    @MainActor func saveLastUpdate(popup: Popup) async {
         var currentPopupList = appState.popup.currentList
 
         currentPopupList.indices.filter {

--- a/SNUTT-2022/SNUTT/Services/PopupService.swift
+++ b/SNUTT-2022/SNUTT/Services/PopupService.swift
@@ -43,7 +43,7 @@ struct PopupService: PopupServiceProtocol {
 
         recentPopupList = recentPopupList.filter { shouldShow(popup: $0) }
 
-        DispatchQueue.main.async { [recentPopupList] in
+        await MainActor.run { [recentPopupList] in
             appState.popup.currentList = recentPopupList
             appState.popup.shouldShowPopup = recentPopupList.isEmpty ? false : true
         }

--- a/SNUTT-2022/SNUTT/Services/PopupService.swift
+++ b/SNUTT-2022/SNUTT/Services/PopupService.swift
@@ -49,7 +49,7 @@ struct PopupService: PopupServiceProtocol {
         }
     }
 
-    func saveLastUpdate(popup: Popup) {
+    @MainActor func saveLastUpdate(popup: Popup) {
         var currentPopupList = appState.popup.currentList
 
         currentPopupList.indices.filter {
@@ -60,10 +60,7 @@ struct PopupService: PopupServiceProtocol {
 
         let currentPopupListDto = currentPopupList.compactMap { PopupDto(from: $0) }
 
-        DispatchQueue.main.async {
-            appState.popup.currentList = currentPopupList
-        }
-
+        appState.popup.currentList = currentPopupList
         userDefaultsRepository.set([PopupDto].self, key: .popupList, value: currentPopupListDto)
     }
 

--- a/SNUTT-2022/SNUTT/Services/SearchService.swift
+++ b/SNUTT-2022/SNUTT/Services/SearchService.swift
@@ -9,15 +9,15 @@ import Foundation
 import SwiftUI
 
 protocol SearchServiceProtocol {
-    func toggle(_ tag: SearchTag)
-    func deselectTag(_ tag: SearchTag)
+    func toggle(_ tag: SearchTag) async
+    func deselectTag(_ tag: SearchTag) async
     func fetchTags(quarter: Quarter) async throws
     func fetchInitialSearchResult() async throws
     func fetchMoreSearchResult() async throws
-    func setIsFilterOpen(_ value: Bool)
-    func setSearchText(_ value: String)
-    func setSelectedLecture(_ value: Lecture?)
-    func initializeSearchState()
+    func setIsFilterOpen(_ value: Bool) async
+    func setSearchText(_ value: String) async
+    func setSelectedLecture(_ value: Lecture?) async
+    func initializeSearchState() async
 }
 
 struct SearchService: SearchServiceProtocol {
@@ -36,11 +36,11 @@ struct SearchService: SearchServiceProtocol {
         appState.timetable
     }
 
-    @MainActor func setLoading(_ value: Bool) {
+    @MainActor private func setLoading(_ value: Bool) async {
         searchState.isLoading = value
     }
 
-    @MainActor func initializeSearchState() {
+    @MainActor func initializeSearchState() async {
         searchState.selectedLecture = nil
         searchState.selectedTagList = []
         searchState.searchResult = nil
@@ -77,9 +77,11 @@ struct SearchService: SearchServiceProtocol {
     }
 
     @MainActor func fetchInitialSearchResult() async throws {
-        setLoading(true)
+        await setLoading(true)
         defer {
-            setLoading(false)
+            Task {
+                await setLoading(false)
+            }
         }
         searchState.pageNum = 0
         try await _fetchSearchResult()
@@ -90,7 +92,7 @@ struct SearchService: SearchServiceProtocol {
         try await _fetchSearchResult()
     }
 
-    @MainActor func toggle(_ tag: SearchTag) {
+    @MainActor func toggle(_ tag: SearchTag) async {
         if let index = searchState.selectedTagList.firstIndex(where: { $0.id == tag.id }) {
             searchState.selectedTagList.remove(at: index)
             return
@@ -99,22 +101,22 @@ struct SearchService: SearchServiceProtocol {
     }
 
     /// We need a separate method that only deselects tags.
-    @MainActor func deselectTag(_ tag: SearchTag) {
+    @MainActor func deselectTag(_ tag: SearchTag) async {
         if let index = searchState.selectedTagList.firstIndex(where: { $0.id == tag.id }) {
             searchState.selectedTagList.remove(at: index)
             return
         }
     }
 
-    @MainActor func setIsFilterOpen(_ value: Bool) {
+    @MainActor func setIsFilterOpen(_ value: Bool) async {
         searchState.isFilterOpen = value
     }
 
-    @MainActor func setSelectedLecture(_ value: Lecture?) {
+    @MainActor func setSelectedLecture(_ value: Lecture?) async {
         searchState.selectedLecture = value
     }
 
-    @MainActor func setSearchText(_ value: String) {
+    @MainActor func setSearchText(_ value: String) async {
         searchState.searchText = value
     }
 }

--- a/SNUTT-2022/SNUTT/Services/SearchService.swift
+++ b/SNUTT-2022/SNUTT/Services/SearchService.swift
@@ -89,7 +89,7 @@ struct SearchService: SearchServiceProtocol {
         searchState.pageNum += 1
         try await _fetchSearchResult()
     }
-    
+
     @MainActor func toggle(_ tag: SearchTag) {
         if let index = searchState.selectedTagList.firstIndex(where: { $0.id == tag.id }) {
             searchState.selectedTagList.remove(at: index)

--- a/SNUTT-2022/SNUTT/Services/SearchService.swift
+++ b/SNUTT-2022/SNUTT/Services/SearchService.swift
@@ -36,19 +36,15 @@ struct SearchService: SearchServiceProtocol {
         appState.timetable
     }
 
-    func setLoading(_ value: Bool) {
-        DispatchQueue.main.async {
-            searchState.isLoading = value
-        }
+    @MainActor func setLoading(_ value: Bool) {
+        searchState.isLoading = value
     }
 
-    func initializeSearchState() {
-        DispatchQueue.main.async {
-            searchState.selectedLecture = nil
-            searchState.selectedTagList = []
-            searchState.searchResult = nil
-            searchState.searchText = ""
-        }
+    @MainActor func initializeSearchState() {
+        searchState.selectedLecture = nil
+        searchState.selectedTagList = []
+        searchState.searchResult = nil
+        searchState.searchText = ""
     }
 
     func fetchTags(quarter: Quarter) async throws {
@@ -80,7 +76,7 @@ struct SearchService: SearchServiceProtocol {
         }
     }
 
-    func fetchInitialSearchResult() async throws {
+    @MainActor func fetchInitialSearchResult() async throws {
         setLoading(true)
         defer {
             setLoading(false)
@@ -93,43 +89,33 @@ struct SearchService: SearchServiceProtocol {
         searchState.pageNum += 1
         try await _fetchSearchResult()
     }
-
-    func toggle(_ tag: SearchTag) {
-        DispatchQueue.main.async {
-            if let index = searchState.selectedTagList.firstIndex(where: { $0.id == tag.id }) {
-                searchState.selectedTagList.remove(at: index)
-                return
-            }
-            searchState.selectedTagList.append(tag)
+    
+    @MainActor func toggle(_ tag: SearchTag) {
+        if let index = searchState.selectedTagList.firstIndex(where: { $0.id == tag.id }) {
+            searchState.selectedTagList.remove(at: index)
+            return
         }
+        searchState.selectedTagList.append(tag)
     }
 
     /// We need a separate method that only deselects tags.
-    func deselectTag(_ tag: SearchTag) {
+    @MainActor func deselectTag(_ tag: SearchTag) {
         if let index = searchState.selectedTagList.firstIndex(where: { $0.id == tag.id }) {
-            DispatchQueue.main.async {
-                searchState.selectedTagList.remove(at: index)
-            }
+            searchState.selectedTagList.remove(at: index)
             return
         }
     }
 
-    func setIsFilterOpen(_ value: Bool) {
-        DispatchQueue.main.async {
-            searchState.isFilterOpen = value
-        }
+    @MainActor func setIsFilterOpen(_ value: Bool) {
+        searchState.isFilterOpen = value
     }
 
-    func setSelectedLecture(_ value: Lecture?) {
-        DispatchQueue.main.async {
-            searchState.selectedLecture = value
-        }
+    @MainActor func setSelectedLecture(_ value: Lecture?) {
+        searchState.selectedLecture = value
     }
 
-    func setSearchText(_ value: String) {
-        DispatchQueue.main.async {
-            searchState.searchText = value
-        }
+    @MainActor func setSearchText(_ value: String) {
+        searchState.searchText = value
     }
 }
 

--- a/SNUTT-2022/SNUTT/Services/TimetableService.swift
+++ b/SNUTT-2022/SNUTT/Services/TimetableService.swift
@@ -17,9 +17,9 @@ protocol TimetableServiceProtocol {
     func updateTimetableTitle(timetableId: String, title: String) async throws
     func updateTimetableTheme(timetableId: String) async throws
     func deleteTimetable(timetableId: String) async throws
-    func selectTimetableTheme(theme: Theme)
+    func selectTimetableTheme(theme: Theme) async
     func createTimetable(title: String, quarter: Quarter) async throws
-    func setTimetableConfig(config: TimetableConfiguration)
+    func setTimetableConfig(config: TimetableConfiguration) async
 }
 
 struct TimetableService: TimetableServiceProtocol {
@@ -112,11 +112,11 @@ struct TimetableService: TimetableServiceProtocol {
         }
     }
 
-    @MainActor func selectTimetableTheme(theme: Theme) {
+    @MainActor func selectTimetableTheme(theme: Theme) async {
         appState.timetable.current?.selectedTheme = theme
     }
 
-    @MainActor func setTimetableConfig(config: TimetableConfiguration) {
+    @MainActor func setTimetableConfig(config: TimetableConfiguration) async {
         appState.timetable.configuration = config
         userDefaultsRepository.set(TimetableConfiguration.self, key: .timetableConfig, value: config)
     }
@@ -125,7 +125,7 @@ struct TimetableService: TimetableServiceProtocol {
         appState.timetable.configuration = userDefaultsRepository.get(TimetableConfiguration.self, key: .timetableConfig, defaultValue: .init())
     }
 
-    @MainActor private func updateState(to currentTimetable: Timetable) {
+    @MainActor private func updateState(to currentTimetable: Timetable) async {
         appState.timetable.current = currentTimetable
     }
 }

--- a/SNUTT-2022/SNUTT/Services/TimetableService.swift
+++ b/SNUTT-2022/SNUTT/Services/TimetableService.swift
@@ -112,26 +112,20 @@ struct TimetableService: TimetableServiceProtocol {
         }
     }
 
-    func selectTimetableTheme(theme: Theme) {
+    @MainActor func selectTimetableTheme(theme: Theme) {
         appState.timetable.current?.selectedTheme = theme
     }
-
-    func setTimetableConfig(config: TimetableConfiguration) {
-        DispatchQueue.main.async {
-            appState.timetable.configuration = config
-        }
+    
+    @MainActor func setTimetableConfig(config: TimetableConfiguration) {
+        appState.timetable.configuration = config
         userDefaultsRepository.set(TimetableConfiguration.self, key: .timetableConfig, value: config)
     }
 
-    func loadTimetableConfig() {
-        DispatchQueue.main.async {
-            appState.timetable.configuration = userDefaultsRepository.get(TimetableConfiguration.self, key: .timetableConfig, defaultValue: .init())
-        }
+    @MainActor func loadTimetableConfig() {
+        appState.timetable.configuration = userDefaultsRepository.get(TimetableConfiguration.self, key: .timetableConfig, defaultValue: .init())
     }
 
-    // TODO: to be refactored
-    @MainActor
-    private func updateState(to currentTimetable: Timetable) {
+    @MainActor private func updateState(to currentTimetable: Timetable) {
         appState.timetable.current = currentTimetable
     }
 }

--- a/SNUTT-2022/SNUTT/Services/TimetableService.swift
+++ b/SNUTT-2022/SNUTT/Services/TimetableService.swift
@@ -58,7 +58,7 @@ struct TimetableService: TimetableServiceProtocol {
     func fetchTimetableList() async throws {
         let dtos = try await timetableRepository.fetchTimetableList()
         let timetables = dtos.map { TimetableMetadata(from: $0) }
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.metadataList = timetables
         }
     }
@@ -66,7 +66,7 @@ struct TimetableService: TimetableServiceProtocol {
     func createTimetable(title: String, quarter: Quarter) async throws {
         let dtos = try await timetableRepository.createTimetable(title: title, year: quarter.year, semester: quarter.semester.rawValue)
         let timetables = dtos.map { TimetableMetadata(from: $0) }
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.metadataList = timetables
         }
     }
@@ -74,7 +74,7 @@ struct TimetableService: TimetableServiceProtocol {
     func copyTimetable(timetableId: String) async throws {
         let dtos = try await timetableRepository.copyTimetable(withTimetableId: timetableId)
         let timetables = dtos.map { TimetableMetadata(from: $0) }
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.metadataList = timetables
         }
     }
@@ -82,7 +82,7 @@ struct TimetableService: TimetableServiceProtocol {
     func updateTimetableTitle(timetableId: String, title: String) async throws {
         let dtos = try await timetableRepository.updateTimetableTitle(withTimetableId: timetableId, withTitle: title)
         let timetables = dtos.map { TimetableMetadata(from: $0) }
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.metadataList = timetables
             if appState.timetable.current?.id == timetableId {
                 appState.timetable.current?.title = title
@@ -94,7 +94,7 @@ struct TimetableService: TimetableServiceProtocol {
         guard let theme = appState.timetable.current?.selectedTheme else { return }
         let dto = try await timetableRepository.updateTimetableTheme(withTimetableId: timetableId, withTheme: theme.rawValue)
         let timetable = Timetable(from: dto)
-        DispatchQueue.main.async {
+        await MainActor.run {
             if appState.timetable.current?.id == timetableId {
                 appState.timetable.current = timetable
             }
@@ -107,7 +107,7 @@ struct TimetableService: TimetableServiceProtocol {
         }
         let dtos = try await timetableRepository.deleteTimetable(withTimetableId: timetableId)
         let timetables = dtos.map { TimetableMetadata(from: $0) }
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.timetable.metadataList = timetables
         }
     }

--- a/SNUTT-2022/SNUTT/Services/TimetableService.swift
+++ b/SNUTT-2022/SNUTT/Services/TimetableService.swift
@@ -115,7 +115,7 @@ struct TimetableService: TimetableServiceProtocol {
     @MainActor func selectTimetableTheme(theme: Theme) {
         appState.timetable.current?.selectedTheme = theme
     }
-    
+
     @MainActor func setTimetableConfig(config: TimetableConfiguration) {
         appState.timetable.configuration = config
         userDefaultsRepository.set(TimetableConfiguration.self, key: .timetableConfig, value: config)

--- a/SNUTT-2022/SNUTT/Services/UserService.swift
+++ b/SNUTT-2022/SNUTT/Services/UserService.swift
@@ -84,7 +84,7 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
     }
 
     private func updateToken(from dto: TokenResponseDto) async throws {
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.user.accessToken = dto.token
         }
         userDefaultsRepository.set(String.self, key: .token, value: dto.token)
@@ -92,7 +92,7 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
     }
 
     private func updateUser(from dto: UserDto) {
-        DispatchQueue.main.async {
+        await MainActor.run {
             appState.user.current = User(from: dto)
         }
         userDefaultsRepository.set(UserDto.self, key: .userDto, value: dto)

--- a/SNUTT-2022/SNUTT/Services/UserService.swift
+++ b/SNUTT-2022/SNUTT/Services/UserService.swift
@@ -59,7 +59,7 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
 
     func deleteUser() async throws {
         try await userRepository.deleteUser()
-        clearUserInfo()
+        await clearUserInfo()
     }
 
     func addDevice(fcmToken: String) async throws {

--- a/SNUTT-2022/SNUTT/Services/UserService.swift
+++ b/SNUTT-2022/SNUTT/Services/UserService.swift
@@ -34,7 +34,7 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
 
     func fetchUser() async throws {
         let dto = try await userRepository.fetchUser()
-        updateUser(from: dto)
+        await updateUser(from: dto)
     }
 
     func changePassword(from oldPassword: String, to newPassword: String) async throws {
@@ -91,7 +91,7 @@ struct UserService: UserServiceProtocol, UserAuthHandler {
         try await fetchUser()
     }
 
-    private func updateUser(from dto: UserDto) {
+    private func updateUser(from dto: UserDto) async {
         await MainActor.run {
             appState.user.current = User(from: dto)
         }

--- a/SNUTT-2022/SNUTT/ViewModels/AccountSettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/AccountSettingViewModel.swift
@@ -22,7 +22,7 @@ extension AccountSettingScene {
             do {
                 try await services.userService.deleteUser()
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
 
@@ -30,7 +30,7 @@ extension AccountSettingScene {
             do {
                 try await services.userService.disconnectFacebook()
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
 
@@ -38,7 +38,7 @@ extension AccountSettingScene {
             do {
                 try await services.userService.addLocalId(id: id, password: password)
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
 
@@ -47,7 +47,7 @@ extension AccountSettingScene {
                 try await services.userService.changePassword(from: oldPassword, to: newPassword)
                 return true
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
                 return false
             }
         }
@@ -59,7 +59,7 @@ extension AccountSettingScene.ViewModel: FacebookLoginProtocol {
         do {
             try await services.userService.connectFacebook(fbId: fbId, fbToken: fbToken)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/FilterSheetViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/FilterSheetViewModel.swift
@@ -14,7 +14,7 @@ class FilterSheetViewModel: BaseViewModel, ObservableObject {
 
     var isFilterOpen: Bool {
         get { _isFilterOpen }
-        set { services.searchService.setIsFilterOpen(newValue) }
+        set { Task { await services.searchService.setIsFilterOpen(newValue) }}
     }
 
     override init(container: DIContainer) {
@@ -31,14 +31,16 @@ class FilterSheetViewModel: BaseViewModel, ObservableObject {
     }
 
     func toggle(_ tag: SearchTag) {
-        services.searchService.toggle(tag)
+        Task {
+            await services.searchService.toggle(tag)
+        }
     }
 
     func fetchInitialSearchResult() async {
         do {
             try await services.searchService.fetchInitialSearchResult()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 

--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -92,11 +92,10 @@ extension LectureDetailScene {
 
         func openLectureTimeSheet(lecture: Binding<Lecture>, timePlace: TimePlace) {
             Task {
-                
-            await services.globalUIService.setIsLectureTimeSheetOpen(true, modifying: timePlace) { modifiedTimePlace in
-                guard let firstIndex = lecture.timePlaces.firstIndex(where: { $0.id == timePlace.id }) else { return }
-                lecture.wrappedValue.timePlaces[firstIndex] = modifiedTimePlace
-            }
+                await services.globalUIService.setIsLectureTimeSheetOpen(true, modifying: timePlace) { modifiedTimePlace in
+                    guard let firstIndex = lecture.timePlaces.firstIndex(where: { $0.id == timePlace.id }) else { return }
+                    lecture.wrappedValue.timePlaces[firstIndex] = modifiedTimePlace
+                }
             }
         }
 

--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -35,7 +35,7 @@ extension LectureDetailScene {
             } catch {
                 if let error = error.asSTError {
                     if error.code == .LECTURE_TIME_OVERLAP {
-                        DispatchQueue.main.async {
+                        await MainActor.run {
                             self.isLectureOverlapped = true
                             self.errorTitle = error.title
                             self.errorMessage = error.content
@@ -69,7 +69,7 @@ extension LectureDetailScene {
             } catch {
                 if let error = error.asSTError {
                     if error.code == .LECTURE_TIME_OVERLAP {
-                        DispatchQueue.main.async {
+                        await MainActor.run {
                             self.isLectureOverlapped = true
                             self.errorTitle = error.title
                             self.errorMessage = error.content

--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -41,7 +41,7 @@ extension LectureDetailScene {
                             self.errorMessage = error.content
                         }
                     } else {
-                        services.globalUIService.presentErrorAlert(error: error)
+                        await services.globalUIService.presentErrorAlert(error: error)
                     }
                 }
                 return false
@@ -53,7 +53,7 @@ extension LectureDetailScene {
                 try await lectureService.addLecture(lecture: lecture, isForced: true)
                 return true
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
                 return false
             }
         }
@@ -75,7 +75,7 @@ extension LectureDetailScene {
                             self.errorMessage = error.content
                         }
                     } else {
-                        services.globalUIService.presentErrorAlert(error: error)
+                        await services.globalUIService.presentErrorAlert(error: error)
                     }
                 }
                 return false
@@ -86,14 +86,17 @@ extension LectureDetailScene {
             do {
                 try await lectureService.deleteLecture(lecture: lecture)
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
 
         func openLectureTimeSheet(lecture: Binding<Lecture>, timePlace: TimePlace) {
-            services.globalUIService.setIsLectureTimeSheetOpen(true, modifying: timePlace) { modifiedTimePlace in
+            Task {
+                
+            await services.globalUIService.setIsLectureTimeSheetOpen(true, modifying: timePlace) { modifiedTimePlace in
                 guard let firstIndex = lecture.timePlaces.firstIndex(where: { $0.id == timePlace.id }) else { return }
                 lecture.wrappedValue.timePlaces[firstIndex] = modifiedTimePlace
+            }
             }
         }
 
@@ -103,7 +106,7 @@ extension LectureDetailScene {
                 guard let current = appState.timetable.current else { return nil }
                 return current.lectures.first(where: { $0.id == lecture.id })
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
             return nil
         }
@@ -112,7 +115,7 @@ extension LectureDetailScene {
             do {
                 try await lectureService.fetchReviewId(courseNumber: lecture.courseNumber, instructor: lecture.instructor, bind: bind)
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
 
@@ -124,7 +127,7 @@ extension LectureDetailScene {
             do {
                 return try await services.courseBookService.fetchSyllabusURL(quarter: currentQuarter, lecture: lecture)
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
                 return ""
             }
         }

--- a/SNUTT-2022/SNUTT/ViewModels/MenuSheetViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MenuSheetViewModel.swift
@@ -15,7 +15,7 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
     @Published private var _isMenuSheetOpen: Bool = false
     var isMenuSheetOpen: Bool {
         get { _isMenuSheetOpen }
-        set { Task {await services.globalUIService.setIsMenuOpen(newValue) }}
+        set { Task { await services.globalUIService.setIsMenuOpen(newValue) }}
     }
 
     @Published private var _isEllipsisSheetOpen: Bool = false
@@ -27,7 +27,7 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
     @Published private var _isThemeSheetOpen: Bool = false
     var isThemeSheetOpen: Bool {
         get { _isThemeSheetOpen }
-        set { Task {await services.globalUIService.closeThemeSheet() }} // close-only;
+        set { Task { await services.globalUIService.closeThemeSheet() }} // close-only;
     }
 
     @Published private var _isRenameSheetOpen: Bool = false
@@ -39,7 +39,7 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
     @Published private var _isCreateSheetOpen: Bool = false
     var isCreateSheetOpen: Bool {
         get { _isCreateSheetOpen }
-        set { Task {await services.globalUIService.closeCreateSheet() }} // close-only;
+        set { Task { await services.globalUIService.closeCreateSheet() }} // close-only;
     }
 
     @Published private var _renameTitle: String = ""
@@ -51,13 +51,13 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
     @Published private var _createTitle: String = ""
     var createTitle: String {
         get { _createTitle }
-        set { Task {await services.globalUIService.setCreateTitle(newValue) }}
+        set { Task { await services.globalUIService.setCreateTitle(newValue) }}
     }
 
     @Published private var _createQuarter: Quarter?
     var createQuarter: Quarter? {
         get { _createQuarter }
-        set { Task {await services.globalUIService.setCreateQuarter(newValue) }}
+        set { Task { await services.globalUIService.setCreateQuarter(newValue) }}
     }
 
     override init(container: DIContainer) {
@@ -95,7 +95,7 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
         return dict
     }
 
-    func openThemeSheet() async  {
+    func openThemeSheet() async {
         if menuState.ellipsisTarget?.id != appState.timetable.current?.id {
             await services.globalUIService.presentErrorAlert(error: .CANT_CHANGE_OTHERS_THEME)
             await services.globalUIService.closeEllipsis()

--- a/SNUTT-2022/SNUTT/ViewModels/MenuSheetViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/MenuSheetViewModel.swift
@@ -15,49 +15,49 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
     @Published private var _isMenuSheetOpen: Bool = false
     var isMenuSheetOpen: Bool {
         get { _isMenuSheetOpen }
-        set { services.globalUIService.setIsMenuOpen(newValue) }
+        set { Task {await services.globalUIService.setIsMenuOpen(newValue) }}
     }
 
     @Published private var _isEllipsisSheetOpen: Bool = false
     var isEllipsisSheetOpen: Bool {
         get { _isEllipsisSheetOpen }
-        set { services.globalUIService.closeEllipsis() } // close-only; the sheets can't open themselves
+        set { Task { await services.globalUIService.closeEllipsis() }} // close-only; the sheets can't open themselves
     }
 
     @Published private var _isThemeSheetOpen: Bool = false
     var isThemeSheetOpen: Bool {
         get { _isThemeSheetOpen }
-        set { services.globalUIService.closeThemeSheet() } // close-only;
+        set { Task {await services.globalUIService.closeThemeSheet() }} // close-only;
     }
 
     @Published private var _isRenameSheetOpen: Bool = false
     var isRenameSheetOpen: Bool {
         get { _isRenameSheetOpen }
-        set { services.globalUIService.closeRenameSheet() } // close-only;
+        set { Task { await services.globalUIService.closeRenameSheet() } } // close-only;
     }
 
     @Published private var _isCreateSheetOpen: Bool = false
     var isCreateSheetOpen: Bool {
         get { _isCreateSheetOpen }
-        set { services.globalUIService.closeCreateSheet() } // close-only;
+        set { Task {await services.globalUIService.closeCreateSheet() }} // close-only;
     }
 
     @Published private var _renameTitle: String = ""
     var renameTitle: String {
         get { _renameTitle }
-        set { services.globalUIService.setRenameTitle(newValue) }
+        set { Task { await services.globalUIService.setRenameTitle(newValue) } }
     }
 
     @Published private var _createTitle: String = ""
     var createTitle: String {
         get { _createTitle }
-        set { services.globalUIService.setCreateTitle(newValue) }
+        set { Task {await services.globalUIService.setCreateTitle(newValue) }}
     }
 
     @Published private var _createQuarter: Quarter?
     var createQuarter: Quarter? {
         get { _createQuarter }
-        set { services.globalUIService.setCreateQuarter(newValue) }
+        set { Task {await services.globalUIService.setCreateQuarter(newValue) }}
     }
 
     override init(container: DIContainer) {
@@ -95,33 +95,35 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
         return dict
     }
 
-    func openThemeSheet() {
+    func openThemeSheet() async  {
         if menuState.ellipsisTarget?.id != appState.timetable.current?.id {
-            services.globalUIService.presentErrorAlert(error: .CANT_CHANGE_OTHERS_THEME)
-            services.globalUIService.closeEllipsis()
+            await services.globalUIService.presentErrorAlert(error: .CANT_CHANGE_OTHERS_THEME)
+            await services.globalUIService.closeEllipsis()
             return
         }
-        services.globalUIService.openThemeSheet()
+        await services.globalUIService.openThemeSheet()
     }
 
-    func openRenameSheet() {
-        services.globalUIService.openRenameSheet()
+    func openRenameSheet() async {
+        await services.globalUIService.openRenameSheet()
     }
 
-    func closeRenameSheet() {
-        services.globalUIService.closeRenameSheet()
+    func closeRenameSheet() async {
+        await services.globalUIService.closeRenameSheet()
     }
 
     func openCreateSheet(withPicker: Bool) {
-        services.globalUIService.openCreateSheet(withPicker: withPicker)
+        Task {
+            await services.globalUIService.openCreateSheet(withPicker: withPicker)
+        }
     }
 
     func selectTimetable(timetableId: String) async {
         do {
-            services.searchService.initializeSearchState()
+            await services.searchService.initializeSearchState()
             try await services.timetableService.fetchTimetable(timetableId: timetableId)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -129,21 +131,23 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.timetableService.copyTimetable(timetableId: timetableId)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
     func openEllipsis(for timetable: TimetableMetadata) {
-        services.globalUIService.openEllipsis(for: timetable)
+        Task {
+            await services.globalUIService.openEllipsis(for: timetable)
+        }
     }
 
     func applyRenameSheet() async {
         guard let timetableId = menuState.ellipsisTarget?.id else { return }
         do {
             try await services.timetableService.updateTimetableTitle(timetableId: timetableId, title: menuState.renameTitle)
-            services.globalUIService.closeRenameSheet()
+            await services.globalUIService.closeRenameSheet()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -151,14 +155,14 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
         guard let timetableId = menuState.ellipsisTarget?.id else { return }
         do {
             try await services.timetableService.deleteTimetable(timetableId: timetableId)
-            services.globalUIService.closeEllipsis()
+            await services.globalUIService.closeEllipsis()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
-    func closeThemeSheet() {
-        services.globalUIService.closeThemeSheet()
+    func closeThemeSheet() async {
+        await services.globalUIService.closeThemeSheet()
     }
 
     func applyThemeSheet() async {
@@ -166,14 +170,14 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
 
         do {
             try await services.timetableService.updateTimetableTheme(timetableId: timetableId)
-            services.globalUIService.closeThemeSheet()
+            await services.globalUIService.closeThemeSheet()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
-    func closeCreateSheet() {
-        services.globalUIService.closeCreateSheet()
+    func closeCreateSheet() async {
+        await services.globalUIService.closeCreateSheet()
     }
 
     func applyCreateSheet() async {
@@ -181,14 +185,14 @@ class MenuSheetViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.timetableService.createTimetable(title: menuState.createTitle, quarter: quarter)
             try await services.timetableService.fetchRecentTimetable() // change current timetable to newly created one
-            services.globalUIService.closeCreateSheet()
+            await services.globalUIService.closeCreateSheet()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
-    func selectTheme(theme: Theme) {
-        services.timetableService.selectTimetableTheme(theme: theme)
+    func selectTheme(theme: Theme) async {
+        await services.timetableService.selectTimetableTheme(theme: theme)
     }
 
     var selectedTheme: Theme {

--- a/SNUTT-2022/SNUTT/ViewModels/OnboardViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/OnboardViewModel.swift
@@ -15,7 +15,7 @@ extension OnboardScene {
             do {
                 try await services.authService.registerWithId(id: id, password: password, email: email)
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
     }
@@ -26,7 +26,7 @@ extension OnboardScene.ViewModel: FacebookLoginProtocol {
         do {
             try await services.authService.loginWithFacebook(id: fbId, token: fbToken)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 }
@@ -41,7 +41,9 @@ extension OnboardScene.ViewModel: ASAuthorizationControllerDelegate {
     }
 
     func authorizationController(controller _: ASAuthorizationController, didCompleteWithError _: Error) {
-        services.globalUIService.presentErrorAlert(error: .WRONG_APPLE_TOKEN)
+        Task {
+            await services.globalUIService.presentErrorAlert(error: .WRONG_APPLE_TOKEN)
+        }
     }
 
     func performAppleSignIn() {
@@ -58,13 +60,13 @@ extension OnboardScene.ViewModel: ASAuthorizationControllerDelegate {
               let tokenData = credentail.identityToken,
               let token = String(data: tokenData, encoding: .utf8)
         else {
-            services.globalUIService.presentErrorAlert(error: .WRONG_APPLE_TOKEN)
+            await services.globalUIService.presentErrorAlert(error: .WRONG_APPLE_TOKEN)
             return
         }
         do {
             try await services.authService.loginWithApple(token: token)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -28,12 +28,12 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
 
     var isFilterOpen: Bool {
         get { _isFilterOpen }
-        set {Task { await services.searchService.setIsFilterOpen(newValue) }}
+        set { Task { await services.searchService.setIsFilterOpen(newValue) }}
     }
 
     var selectedLecture: Lecture? {
         get { _selectedLecture }
-        set {Task { await services.searchService.setSelectedLecture(newValue) }}
+        set { Task { await services.searchService.setSelectedLecture(newValue) }}
     }
 
     var currentTimetableWithSelection: Timetable? {
@@ -89,10 +89,9 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         }
     }
 
-    func deselectTag(_ tag: SearchTag){
+    func deselectTag(_ tag: SearchTag) {
         Task {
             await services.searchService.deselectTag(tag)
-            
         }
     }
 

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -99,7 +99,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         } catch {
             if let error = error.asSTError {
                 if error.code == .LECTURE_TIME_OVERLAP {
-                    DispatchQueue.main.async {
+                    await MainActor.run {
                         self.isLectureOverlapped = true
                         self.errorTitle = error.title
                         self.errorMessage = error.content

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -23,17 +23,17 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
 
     var searchText: String {
         get { _searchText }
-        set { services.searchService.setSearchText(newValue) }
+        set { Task { await services.searchService.setSearchText(newValue) }}
     }
 
     var isFilterOpen: Bool {
         get { _isFilterOpen }
-        set { services.searchService.setIsFilterOpen(newValue) }
+        set {Task { await services.searchService.setIsFilterOpen(newValue) }}
     }
 
     var selectedLecture: Lecture? {
         get { _selectedLecture }
-        set { services.searchService.setSelectedLecture(newValue) }
+        set {Task { await services.searchService.setSelectedLecture(newValue) }}
     }
 
     var currentTimetableWithSelection: Timetable? {
@@ -65,19 +65,19 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.searchService.fetchTags(quarter: currentTimetable.quarter)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
-    func initializeSearchState() {
-        services.searchService.initializeSearchState()
+    func initializeSearchState() async {
+        await services.searchService.initializeSearchState()
     }
 
     func fetchInitialSearchResult() async {
         do {
             try await services.searchService.fetchInitialSearchResult()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -85,12 +85,15 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.searchService.fetchMoreSearchResult()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
-    func deselectTag(_ tag: SearchTag) {
-        services.searchService.deselectTag(tag)
+    func deselectTag(_ tag: SearchTag){
+        Task {
+            await services.searchService.deselectTag(tag)
+            
+        }
     }
 
     func addLecture(lecture: Lecture) async {
@@ -105,7 +108,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
                         self.errorMessage = error.content
                     }
                 } else {
-                    services.globalUIService.presentErrorAlert(error: error)
+                    await services.globalUIService.presentErrorAlert(error: error)
                 }
             }
         }
@@ -115,7 +118,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.lectureService.fetchReviewId(courseNumber: lecture.courseNumber, instructor: lecture.instructor, bind: bind)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -123,7 +126,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.lectureService.addLecture(lecture: lecture, isForced: true)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -17,7 +17,7 @@ class SettingViewModel: BaseViewModel {
         do {
             try await services.authService.logout()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -25,7 +25,7 @@ class SettingViewModel: BaseViewModel {
         do {
             try await services.userService.fetchUser()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -41,14 +41,14 @@ class SettingViewModel: BaseViewModel {
 
     func sendFeedback(email: String, message: String) async -> Bool {
         if !Validation.check(email: email) {
-            services.globalUIService.presentErrorAlert(error: .INVALID_EMAIL)
+            await services.globalUIService.presentErrorAlert(error: .INVALID_EMAIL)
             return false
         }
         do {
             try await services.etcService.sendFeedback(email: email, message: message)
             return true
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
             return false
         }
     }

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -37,15 +37,15 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
         services.courseBookService.isNewCourseBookAvailable()
     }
 
-    func setIsMenuOpen(_ value: Bool) {
-        services.globalUIService.setIsMenuOpen(value)
+    func setIsMenuOpen(_ value: Bool) async {
+        await services.globalUIService.setIsMenuOpen(value)
     }
 
     func fetchRecentTimetable() async {
         do {
             try await timetableService.fetchRecentTimetable()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -53,7 +53,7 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
         do {
             try await timetableService.fetchTimetableList()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -61,7 +61,7 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.courseBookService.fetchCourseBookList()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -69,7 +69,7 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.notificationService.fetchInitialNotifications(updateLastRead: updateLastRead)
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -77,7 +77,7 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.notificationService.fetchMoreNotifications()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -85,7 +85,7 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.notificationService.fetchUnreadNotificationCount()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
     }
 
@@ -93,12 +93,8 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
         do {
             try await services.userService.fetchUser()
         } catch {
-            services.globalUIService.presentErrorAlert(error: error)
+            await services.globalUIService.presentErrorAlert(error: error)
         }
-    }
-
-    func loadTimetableConfig() {
-        timetableService.loadTimetableConfig()
     }
 
     private var timetableService: TimetableServiceProtocol {

--- a/SNUTT-2022/SNUTT/Views/Components/MenuSheets/EllipsisSheetButton.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/MenuSheets/EllipsisSheetButton.swift
@@ -14,11 +14,13 @@ struct EllipsisSheetButton: View {
     /// An optional property used to fix animation glitch in iOS 16. See this [Pull Request](https://github.com/wafflestudio/snutt-ios/pull/132).
     var isSheetOpen: Bool = false
 
-    let action: () -> Void
+    let action: () async -> Void
 
     var body: some View {
         Button {
-            action()
+            Task {
+                await action()
+            }
         } label: {
             HStack {
                 Image(imageName)

--- a/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuCreateSheet.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuCreateSheet.swift
@@ -14,7 +14,7 @@ struct MenuCreateSheet: View {
 
     var quarterChoices: [Quarter]
 
-    var cancel: () -> Void
+    var cancel: () async -> Void
     var confirm: () async -> Void
 
     var showPicker: Bool {

--- a/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuEllipsisSheet.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuEllipsisSheet.swift
@@ -9,16 +9,16 @@ import SwiftUI
 
 struct MenuEllipsisSheet: View {
     @Binding var isOpen: Bool
-    var openRenameSheet: () -> Void
+    var openRenameSheet: () async -> Void
     var deleteTimetable: () async -> Void
-    var openThemeSheet: () -> Void
+    var openThemeSheet: () async -> Void
     @State private var isDeleteAlertPresented = false
 
     var body: some View {
         Sheet(isOpen: $isOpen, orientation: .bottom(maxHeight: 180)) {
             VStack(spacing: 0) {
                 EllipsisSheetButton(imageName: "pen", text: "이름 변경", isSheetOpen: isOpen) {
-                    openRenameSheet()
+                    await openRenameSheet()
                 }
 
                 EllipsisSheetButton(imageName: "trash", text: "시간표 삭제", isSheetOpen: isOpen) {
@@ -34,7 +34,7 @@ struct MenuEllipsisSheet: View {
                 }
 
                 EllipsisSheetButton(imageName: "palette", text: "시간표 테마 설정", isSheetOpen: isOpen) {
-                    openThemeSheet()
+                    await openThemeSheet()
                 }
             }
         }

--- a/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuRenameSheet.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuRenameSheet.swift
@@ -11,7 +11,7 @@ struct MenuRenameSheet: View {
     @Binding var isOpen: Bool
     @Binding var titleText: String
 
-    var cancel: () -> Void
+    var cancel: () async -> Void
     var confirm: () async -> Void
 
     var body: some View {

--- a/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuSheetTopBar.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuSheetTopBar.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MenuSheetTopBar: View {
-    var cancel: () -> Void
+    var cancel: () async -> Void
     var confirm: () async -> Void
     var confirmDisabled: Bool = false
 
@@ -18,7 +18,9 @@ struct MenuSheetTopBar: View {
     var body: some View {
         HStack {
             Button {
-                cancel()
+                Task {
+                    await cancel()
+                }
             } label: {
                 Text("취소")
                     .animation(.customSpring, value: isSheetOpen)

--- a/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuThemeSheet.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/MenuSheets/MenuThemeSheet.swift
@@ -11,9 +11,9 @@ struct MenuThemeSheet: View {
     @Binding var isOpen: Bool
     var selectedTheme: Theme
 
-    var cancel: () -> Void
+    var cancel: () async -> Void
     var confirm: () async -> Void
-    var select: (Theme) -> Void
+    var select: (Theme) async -> Void
 
     var body: some View {
         Sheet(isOpen: $isOpen,
@@ -28,7 +28,9 @@ struct MenuThemeSheet: View {
                     HStack(spacing: 20) {
                         ForEach(Theme.allCases, id: \.rawValue) { theme in
                             Button {
-                                select(theme)
+                                Task {
+                                    await select(theme)
+                                }
                             } label: {
                                 VStack {
                                     Image(theme.imageName)

--- a/SNUTT-2022/SNUTT/Views/Components/NavBarButton.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/NavBarButton.swift
@@ -9,11 +9,13 @@ import SwiftUI
 
 struct NavBarButton: View {
     let imageName: String
-    let action: () -> Void
+    let action: () async -> Void
 
     var body: some View {
         Button {
-            action()
+            Task {
+                await action()
+            }
         } label: {
             Image(imageName)
         }

--- a/SNUTT-2022/SNUTT/Views/Components/PopupView.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/PopupView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct PopupView: View {
     let popup: Popup
     let dismissOnce: (PopupView) -> Void
-    let dismissNdays: (PopupView) -> Void
+    let dismissNdays: (PopupView) async -> Void
 
     var body: some View {
         AsyncImage(url: URL(string: popup.imageURL)!, transaction: Transaction(animation: .customSpring)) { phase in
@@ -25,7 +25,9 @@ struct PopupView: View {
                         Spacer()
 
                         Button {
-                            dismissNdays(self)
+                            Task {
+                                await dismissNdays(self)
+                            }
                         } label: {
                             Text("당분간 보지 않기")
                                 .foregroundColor(.white)

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchBar.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchBar.swift
@@ -13,7 +13,7 @@ struct SearchBar: View {
     @Binding var isFilterOpen: Bool
     var shouldShowCancelButton: Bool
     var action: () async -> Void
-    var cancel: () -> Void
+    var cancel: () async -> Void
 
     @State private var isEditing = false
     @FocusState private var isFocused: Bool
@@ -74,7 +74,9 @@ struct SearchBar: View {
                             isFocused = false
                             text = ""
                             showCancel = false
-                            cancel()
+                            Task {
+                                await cancel()
+                            }
                         }
                     }) {
                         Text("취소")

--- a/SNUTT-2022/SNUTT/Views/Components/Sheet.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Sheet.swift
@@ -15,7 +15,7 @@ struct Sheet<Content>: View where Content: View {
     var sheetOpacity: CGFloat = 1
     var disableBackgroundTap: Bool = false
     var disableDragGesture: Bool = false
-    var onBackgroundTap: (() -> Void)?
+    var onBackgroundTap: (() async -> Void)?
     @ViewBuilder var content: () -> Content
 
     @GestureState private var translation: CGFloat = 0
@@ -50,7 +50,9 @@ struct Sheet<Content>: View where Content: View {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             self.isOpen = false
                         }
-                        onBackgroundTap?()
+                        Task {
+                            await onBackgroundTap?()
+                        }
                     }
                 }
 

--- a/SNUTT-2022/SNUTT/Views/Components/UITextEditor.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/UITextEditor.swift
@@ -65,15 +65,13 @@ struct UITextEditor: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextView, context _: Context) {
-        DispatchQueue.main.async {
-            if !uiView.isFirstResponder {
-                // When this uiView is the first responder, `uiView.delegate` takes care of all the view updates.
-                // When it's not, manually call delegate method to trigger ui update.
-                uiView.text = text
-                uiView.delegate?.textViewDidChange?(uiView)
-            }
-            self.textDidChange(uiView)
+        if !uiView.isFirstResponder {
+            // When this uiView is the first responder, `uiView.delegate` takes care of all the view updates.
+            // When it's not, manually call delegate method to trigger ui update.
+            uiView.text = text
+            uiView.delegate?.textViewDidChange?(uiView)
         }
+        self.textDidChange(uiView)
     }
 
     func makeCoordinator() -> Coordinator {

--- a/SNUTT-2022/SNUTT/Views/Components/UITextEditor.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/UITextEditor.swift
@@ -71,7 +71,7 @@ struct UITextEditor: UIViewRepresentable {
             uiView.text = text
             uiView.delegate?.textViewDidChange?(uiView)
         }
-        self.textDidChange(uiView)
+        textDidChange(uiView)
     }
 
     func makeCoordinator() -> Coordinator {

--- a/SNUTT-2022/SNUTT/Views/Components/UITextEditor.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/UITextEditor.swift
@@ -65,13 +65,15 @@ struct UITextEditor: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextView, context _: Context) {
-        if !uiView.isFirstResponder {
-            // When this uiView is the first responder, `uiView.delegate` takes care of all the view updates.
-            // When it's not, manually call delegate method to trigger ui update.
-            uiView.text = text
-            uiView.delegate?.textViewDidChange?(uiView)
+        DispatchQueue.main.async {
+            if !uiView.isFirstResponder {
+                // When this uiView is the first responder, `uiView.delegate` takes care of all the view updates.
+                // When it's not, manually call delegate method to trigger ui update.
+                uiView.text = text
+                uiView.delegate?.textViewDidChange?(uiView)
+            }
+            textDidChange(uiView)
         }
-        textDidChange(uiView)
     }
 
     func makeCoordinator() -> Coordinator {

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -38,9 +38,7 @@ struct SNUTTView: View {
                     TabScene(tabType: .timetable) {
                         TimetableScene(viewModel: .init(container: viewModel.container))
                             .background(NavigationBarReader { navbar in
-                                DispatchQueue.main.async {
-                                    navigationBarHeight = navbar.frame.height
-                                }
+                                navigationBarHeight = navbar.frame.height
                             })
                     }
                     TabScene(tabType: .search) {
@@ -161,7 +159,7 @@ enum TabType: String {
 
 // TODO: move elsewhere if needed
 struct NavigationBarReader: UIViewControllerRepresentable {
-    var callback: (UINavigationBar) -> Void
+    var callback: @MainActor (UINavigationBar) -> Void
     private let proxyController = ViewController()
 
     func makeUIViewController(context _: UIViewControllerRepresentableContext<NavigationBarReader>) -> UIViewController {
@@ -172,7 +170,7 @@ struct NavigationBarReader: UIViewControllerRepresentable {
     func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<NavigationBarReader>) {}
 
     private class ViewController: UIViewController {
-        var callback: (UINavigationBar) -> Void = { _ in }
+        var callback: @MainActor (UINavigationBar) -> Void = { _ in }
 
         override func viewWillAppear(_ animated: Bool) {
             super.viewWillAppear(animated)

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -136,7 +136,7 @@ extension SNUTTView {
             do {
                 try await services.popupService.getRecentPopupList()
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
     }
@@ -159,7 +159,7 @@ enum TabType: String {
 
 // TODO: move elsewhere if needed
 struct NavigationBarReader: UIViewControllerRepresentable {
-    var callback: @MainActor (UINavigationBar) -> Void
+    var callback: @MainActor (UINavigationBar) async -> Void
     private let proxyController = ViewController()
 
     func makeUIViewController(context _: UIViewControllerRepresentableContext<NavigationBarReader>) -> UIViewController {
@@ -170,12 +170,14 @@ struct NavigationBarReader: UIViewControllerRepresentable {
     func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<NavigationBarReader>) {}
 
     private class ViewController: UIViewController {
-        var callback: @MainActor (UINavigationBar) -> Void = { _ in }
+        var callback: @MainActor (UINavigationBar) async -> Void = { _ in }
 
         override func viewWillAppear(_ animated: Bool) {
             super.viewWillAppear(animated)
             if let navBar = navigationController {
-                callback(navBar.navigationBar)
+                Task {
+                    await callback(navBar.navigationBar)
+                }
             }
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -213,7 +213,7 @@ struct LectureDetailScene: View {
                             Button("초기화", role: .destructive, action: {
                                 Task {
                                     guard let originalLecture = await viewModel.resetLecture(lecture: lecture) else { return }
-                                    DispatchQueue.main.async {
+                                    await MainActor.run {
                                         lecture = originalLecture
                                         editMode = .inactive
                                         resignFirstResponder()

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureTimeSheetScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureTimeSheetScene.swift
@@ -40,7 +40,7 @@ extension LectureTimeSheetScene {
         @Published private var _isOpen: Bool = false
         var isOpen: Bool {
             get { _isOpen }
-            set { services.globalUIService.setIsLectureTimeSheetOpen(newValue, modifying: nil, action: nil) } // close-only
+            set { Task {await services.globalUIService.setIsLectureTimeSheetOpen(newValue, modifying: nil, action: nil) }} // close-only
         }
 
         override init(container: DIContainer) {
@@ -79,10 +79,20 @@ extension LectureTimeSheetScene {
 
 #if DEBUG
     struct LectureTimeSheetScene_Previews: PreviewProvider {
+        
+        
+        
+        
         static var previews: some View {
-            let container: DIContainer = .preview
-            let _ = container.services.globalUIService.setIsLectureTimeSheetOpen(true, modifying: nil, action: nil)
+            let container: DIContainer = {
+                let container = DIContainer.preview
+                Task {
+                    await container.services.globalUIService.setIsLectureTimeSheetOpen(true, modifying: nil, action: nil)
 
+                }
+                return container
+            }()
+            
             LectureTimeSheetScene(viewModel: .init(container: container))
                 .background(.blue)
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureTimeSheetScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureTimeSheetScene.swift
@@ -40,7 +40,7 @@ extension LectureTimeSheetScene {
         @Published private var _isOpen: Bool = false
         var isOpen: Bool {
             get { _isOpen }
-            set { Task {await services.globalUIService.setIsLectureTimeSheetOpen(newValue, modifying: nil, action: nil) }} // close-only
+            set { Task { await services.globalUIService.setIsLectureTimeSheetOpen(newValue, modifying: nil, action: nil) }} // close-only
         }
 
         override init(container: DIContainer) {
@@ -79,20 +79,15 @@ extension LectureTimeSheetScene {
 
 #if DEBUG
     struct LectureTimeSheetScene_Previews: PreviewProvider {
-        
-        
-        
-        
         static var previews: some View {
             let container: DIContainer = {
                 let container = DIContainer.preview
                 Task {
                     await container.services.globalUIService.setIsLectureTimeSheetOpen(true, modifying: nil, action: nil)
-
                 }
                 return container
             }()
-            
+
             LectureTimeSheetScene(viewModel: .init(container: container))
                 .background(.blue)
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LoginScene.swift
@@ -54,7 +54,7 @@ extension LoginScene {
             do {
                 try await services.authService.loginWithId(id: id, password: password)
             } catch {
-                services.globalUIService.presentErrorAlert(error: error)
+                await services.globalUIService.presentErrorAlert(error: error)
             }
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/MenuSheetScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/MenuSheetScene.swift
@@ -65,7 +65,7 @@ struct MenuSheetScene: View {
                         container.appState.menu.isOpen.toggle()
                     }
                     NavBarButton(imageName: "menu.ellipsis") {
-                        container.services.globalUIService.openEllipsis(for: .init(id: "4", year: 2332, semester: 2, title: "32323", updatedAt: "3232", totalCredit: 3))
+                        await container.services.globalUIService.openEllipsis(for: .init(id: "4", year: 2332, semester: 2, title: "32323", updatedAt: "3232", totalCredit: 3))
                     }
                 }
                 MenuSheetScene(viewModel: .init(container: container))

--- a/SNUTT-2022/SNUTT/Views/Scenes/PopupScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/PopupScene.swift
@@ -43,8 +43,8 @@ extension PopupScene {
             services.popupService.showNextPopup()
         }
 
-        func dismissNdays(popupView: PopupView) {
-            services.popupService.saveLastUpdate(popup: popupView.popup)
+        func dismissNdays(popupView: PopupView) async {
+            await services.popupService.saveLastUpdate(popup: popupView.popup)
             services.popupService.showNextPopup()
         }
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/TimetableSettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/TimetableSettingScene.swift
@@ -87,7 +87,7 @@ extension TimetableSettingScene {
 
         var timetableConfig: TimetableConfiguration {
             get { _timetableConfig }
-            set { services.timetableService.setTimetableConfig(config: newValue) }
+            set { Task { await services.timetableService.setTimetableConfig(config: newValue) }}
         }
 
         var minHour: Date {

--- a/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
@@ -36,7 +36,7 @@ struct TimetableScene: View {
                     ToolbarItem(placement: .principal) {
                         HStack {
                             NavBarButton(imageName: "nav.menu") {
-                                viewModel.setIsMenuOpen(true)
+                                await viewModel.setIsMenuOpen(true)
                             }
                             .circleBadge(condition: viewModel.isNewCourseBookAvailable)
 


### PR DESCRIPTION
- Swift Concurrency를 사용해서 테스트를 짜고 있었는데, DispatchQueue.main.async로 상태를 업데이트해주다보니 별도의 작업 흐름이 생겨서 assert문의 순서를 보장하기 어려운 문제가 있었습니다. 이를 해결하기 위해 적용 가능한 부분은 모두 MainActor를 사용하도록 변경했습니다.
- 사소하지만 성능상 이점도 조금 있을거에요.
- 앞으로도 DispatchQueue.main.async를 조금씩 deprecate하는 것이 좋을 것 같습니다.