### PR TITLE
강의 검색 결과에서 `제거하기` 버튼 추가

### DIFF
--- a/SNUTT-2022/SNUTT/Models/Lecture.swift
+++ b/SNUTT-2022/SNUTT/Models/Lecture.swift
@@ -83,6 +83,13 @@ struct Lecture: Identifiable {
     }
 }
 
+/// for non-custom Lecture
+extension Lecture: Equatable {
+    static func == (lhs: Lecture, rhs: Lecture) -> Bool {
+        return lhs.courseNumber == rhs.courseNumber && lhs.lectureNumber == rhs.lectureNumber
+    }
+}
+
 struct LectureColor: Hashable {
     var fg: Color
     var bg: Color

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -110,7 +110,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
             }
         }
     }
-    
+
     func deleteLecture(selected: Lecture) async {
         guard let lecture = getSameLecture(selected) else { return }
         do {
@@ -120,7 +120,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
             services.globalUIService.presentErrorAlert(error: error)
         }
     }
-    
+
     func getSameLecture(_ lecture: Lecture) -> Lecture? {
         timetableState.current?.lectures.filter { $0 == lecture }.first
     }

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -112,7 +112,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
     }
 
     func deleteLecture(selected: Lecture) async {
-        guard let lecture = getSameLecture(selected) else { return }
+        guard let lecture = getExistingLecture(selected) else { return }
         do {
             try await services.lectureService.deleteLecture(lecture: lecture)
             services.searchService.setSelectedLecture(nil)
@@ -121,7 +121,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         }
     }
 
-    func getSameLecture(_ lecture: Lecture) -> Lecture? {
+    func getExistingLecture(_ lecture: Lecture) -> Lecture? {
         timetableState.current?.lectures.filter { $0 == lecture }.first
     }
 

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -110,6 +110,20 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
             }
         }
     }
+    
+    func deleteLecture(selected: Lecture) async {
+        guard let lecture = getSameLecture(selected) else { return }
+        do {
+            try await services.lectureService.deleteLecture(lecture: lecture)
+            services.searchService.setSelectedLecture(nil)
+        } catch {
+            services.globalUIService.presentErrorAlert(error: error)
+        }
+    }
+    
+    func getSameLecture(_ lecture: Lecture) -> Lecture? {
+        timetableState.current?.lectures.filter { $0 == lecture }.first
+    }
 
     func fetchReviewId(of lecture: Lecture, bind: Binding<String>) async {
         do {

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -11,7 +11,9 @@ struct SearchLectureCell: View {
     let lecture: Lecture
     let selected: Bool
     let addLecture: (Lecture) async -> Void
+    let deleteLecture: (Lecture) async -> Void
     let fetchReviewId: (Lecture, Binding<String>) async -> Void
+    let isInTimetable: Bool
 
     @State var showingDetailPage = false
     @State private var showReviewWebView: Bool = false
@@ -69,14 +71,26 @@ struct SearchLectureCell: View {
                             }
                         }
 
-                        Button {
-                            Task {
-                                await addLecture(lecture)
+                        if isInTimetable {
+                            Button {
+                                Task {
+                                    await deleteLecture(lecture)
+                                }
+                            } label: {
+                                Text("제거하기")
+                                    .frame(maxWidth: .infinity)
+                                    .font(STFont.details)
                             }
-                        } label: {
-                            Text("+ 추가하기")
-                                .frame(maxWidth: .infinity)
-                                .font(STFont.details)
+                        } else {
+                            Button {
+                                Task {
+                                    await addLecture(lecture)
+                                }
+                            } label: {
+                                Text("+ 추가하기")
+                                    .frame(maxWidth: .infinity)
+                                    .font(STFont.details)
+                            }
                         }
                     }
                     /// This `sheet` modifier should be called on `HStack` to prevent animation glitch when `dismiss`ed.

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct SearchLectureList: View {
     let data: [Lecture]
     let fetchMore: () async -> Void
+    let sameLecture: (Lecture) -> Lecture?
     let addLecture: (Lecture) async -> Void
+    let deleteLecture: (Lecture) async -> Void
     let fetchReviewId: (Lecture, Binding<String>) async -> Void
     let overwriteLecture: (Lecture) async -> Void
     let errorTitle: String
@@ -25,7 +27,9 @@ struct SearchLectureList: View {
                     SearchLectureCell(lecture: lecture,
                                       selected: selected?.id == lecture.id,
                                       addLecture: addLecture,
-                                      fetchReviewId: fetchReviewId)
+                                      deleteLecture: deleteLecture,
+                                      fetchReviewId: fetchReviewId,
+                                      isInTimetable: sameLecture(lecture) != nil)
                         .task {
                             if lecture.id == data.last?.id {
                                 await fetchMore()

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SearchLectureList: View {
     let data: [Lecture]
     let fetchMore: () async -> Void
-    let sameLecture: (Lecture) -> Lecture?
+    let existingLecture: (Lecture) -> Lecture?
     let addLecture: (Lecture) async -> Void
     let deleteLecture: (Lecture) async -> Void
     let fetchReviewId: (Lecture, Binding<String>) async -> Void
@@ -29,7 +29,7 @@ struct SearchLectureList: View {
                                       addLecture: addLecture,
                                       deleteLecture: deleteLecture,
                                       fetchReviewId: fetchReviewId,
-                                      isInTimetable: sameLecture(lecture) != nil)
+                                      isInTimetable: existingLecture(lecture) != nil)
                         .task {
                             if lecture.id == data.last?.id {
                                 await fetchMore()

--- a/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
@@ -62,7 +62,7 @@ struct SearchLectureScene: View {
                     } else {
                         SearchLectureList(data: viewModel.searchResult!,
                                           fetchMore: viewModel.fetchMoreSearchResult,
-                                          sameLecture: viewModel.getSameLecture,
+                                          existingLecture: viewModel.getExistingLecture,
                                           addLecture: viewModel.addLecture,
                                           deleteLecture: viewModel.deleteLecture,
                                           fetchReviewId: viewModel.fetchReviewId(of:bind:),

--- a/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
@@ -62,7 +62,9 @@ struct SearchLectureScene: View {
                     } else {
                         SearchLectureList(data: viewModel.searchResult!,
                                           fetchMore: viewModel.fetchMoreSearchResult,
+                                          sameLecture: viewModel.getSameLecture,
                                           addLecture: viewModel.addLecture,
+                                          deleteLecture: viewModel.deleteLecture,
                                           fetchReviewId: viewModel.fetchReviewId(of:bind:),
                                           overwriteLecture: viewModel.overwriteLecture(lecture:),
                                           errorTitle: viewModel.errorTitle,


### PR DESCRIPTION
## 수정사항
- 강의 검색 결과에서 시간표에 이미 존재하는 강의인 경우 `제거하기` 버튼을 사용할 수 있도록 수정했습니다.