### PR TITLE
Xcode 14.1 버전으로 Archiving 하도록 변경

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         # see https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md for available versions
         xcode: 
           - '13.4.1'
+          - '14.1'
         macos: ['macos-12']
         command: ['build', 'test']
         scheme: ['SNUTT']

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       GIT_TAG_NAME: ${{ github.ref_name }}
-      XCODE_VERSION: '13.4.1'
+      XCODE_VERSION: '14.1'
 
     runs-on: macos-12
 

--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -1994,7 +1994,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
-				kind = upToNextMinorVersion;
+				kind = upToNextMajorVersion;
 				minimumVersion = 10.0.0;
 			};
 		};

--- a/SNUTT-2022/SNUTT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "5c4893c55f9d6114e2bb7c691d7ffd81208ac713",
-        "version" : "10.0.0"
+        "revision" : "c24031ad9410c746c49deddc739fdf311a386fc7",
+        "version" : "10.2.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "e3dd02f390cae79a7073b46dfb0cb6b60c48401b",
-        "version" : "10.0.0"
+        "revision" : "71eb6700dd53a851473c48d392f00a3ab26699a6",
+        "version" : "10.1.0"
       }
     },
     {


### PR DESCRIPTION
- 앱스토어/테스트플라이트 배포를 위한 아카이빙은 xcode 14.1 버전을 사용하도록 변경했습니다.
- test, build 는 13.4.1과 14.1 환경 모두에서 진행하도록 변경했습니다.

---

@peng-u-0807 
- #178 에서 13.4.1 버전 호환성 문제를 해결한 줄 알았지만.. dSym 파일을 Crashlytics에 자동으로 업로드하도록 프로젝트 세팅을 변경하는 과정에서 또다른 문제가 발생해서 아카이빙 자체는 14버전으로 진행하고자 합니다.
- 그리고 제가 벤투라로 올려버려서 더이상 13.4.1 버전 설치가 안되네요 😢