### PR TITLE
Refactor webviews (feat. preloading, bridge, etc.)

### DIFF
--- a/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
+++ b/SNUTT-2022/SNUTT.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		BE28036828E8883700B2B1AB /* WebViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE28036728E8883700B2B1AB /* WebViewProtocol.swift */; };
 		BE28036A28E93EEF00B2B1AB /* LoginScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE28036928E93EEF00B2B1AB /* LoginScene.swift */; };
 		BE28036C28E9F0B100B2B1AB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BE28036B28E9F0B100B2B1AB /* LaunchScreen.storyboard */; };
+		BE2CB3632959C0CC00FCF0F0 /* ReviewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2CB3622959C0CC00FCF0F0 /* ReviewState.swift */; };
 		BE419B83288B8B8600FA9590 /* Timetable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD41A5F27E5CC7700CF380E /* Timetable.swift */; };
 		BE419B84288B8B8F00FA9590 /* TimePlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE982FBB281D5227005F71E6 /* TimePlace.swift */; };
 		BE419B85288B8B8F00FA9590 /* Lecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF507427F4289B00CDCC13 /* Lecture.swift */; };
@@ -318,6 +319,7 @@
 		BE28036728E8883700B2B1AB /* WebViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProtocol.swift; sourceTree = "<group>"; };
 		BE28036928E93EEF00B2B1AB /* LoginScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScene.swift; sourceTree = "<group>"; };
 		BE28036B28E9F0B100B2B1AB /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		BE2CB3622959C0CC00FCF0F0 /* ReviewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewState.swift; sourceTree = "<group>"; };
 		BE419B8C288B8C5A00FA9590 /* View+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Debug.swift"; sourceTree = "<group>"; };
 		BE419B99288B915800FA9590 /* TimetableUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimetableUtils.swift; sourceTree = "<group>"; };
 		BE4B0EB528735005005FE164 /* MenuSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetViewModel.swift; sourceTree = "<group>"; };
@@ -511,6 +513,7 @@
 				B87B315928D5A70F005C170B /* SearchState.swift */,
 				B87B315A28D5A70F005C170B /* TimetableState.swift */,
 				B87B315828D5A70F005C170B /* UserState.swift */,
+				BE2CB3622959C0CC00FCF0F0 /* ReviewState.swift */,
 				B87DF6F82918B7AD008BB95B /* PopupState.swift */,
 			);
 			path = States;
@@ -1233,6 +1236,7 @@
 				B8B22D1629311F6200AB88F3 /* EmptyLectureList.swift in Sources */,
 				BE28036228E884F400B2B1AB /* ReviewWebView.swift in Sources */,
 				BEB3B6A528CDE1FD00E56062 /* TimeUtils.swift in Sources */,
+				BE2CB3632959C0CC00FCF0F0 /* ReviewState.swift in Sources */,
 				BEBCC29C28EF4C6100732304 /* OnLoadModifier.swift in Sources */,
 				B8F40EB128980DE00021A2A9 /* TermsOfServiceView.swift in Sources */,
 				BE1D2B3A28014527008F9134 /* Weekday.swift in Sources */,

--- a/SNUTT-2022/SNUTT/AppState/AppState.swift
+++ b/SNUTT-2022/SNUTT/AppState/AppState.swift
@@ -18,6 +18,7 @@ class AppState {
     var menu = MenuState()
     var notification = NotificationState()
     var popup = PopupState()
+    var review = ReviewState()
 }
 
 #if DEBUG

--- a/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
@@ -25,22 +25,21 @@ class WebViewPreloadManager {
         if eventSignal != nil && webView != nil {
             return
         }
-        self.url = url
         eventSignal = eventSignal ?? .init()
         webView = webView ?? WKWebView(cookies: NetworkConfiguration.getCookiesFrom(accessToken: accessToken))
         coordinator = coordinator ?? Coordinator(eventSignal: eventSignal!)
-        webView?.allowsBackForwardNavigationGestures = true
         webView?.scrollView.bounces = false
         webView?.backgroundColor = UIColor(STColor.systemBackground)
         webView?.isOpaque = false
         webView?.configuration.userContentController.add(coordinator!, name: MessageHandlerType.snutt.rawValue)
-        webView?.load(URLRequest(url: url))
+        reload(url: url)
         bindEventSignal()
     }
 
     func reload(url: URL? = nil) {
         guard let url = url ?? self.url else { return }
         webView?.load(URLRequest(url: url))
+        webView?.allowsBackForwardNavigationGestures = url == WebViewType.review.url
         self.url = url
     }
 

--- a/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
@@ -5,24 +5,22 @@
 //  Created by 박신홍 on 2022/12/26.
 //
 
-import WebKit
 import Combine
 import SwiftUI
-
+import WebKit
 
 class ReviewState {
     let preloadedMain = WebViewPreloadManager()
     let preloadedDetail = WebViewPreloadManager()
 }
 
-
 class WebViewPreloadManager {
-    var url: URL? = nil
-    var webView: WKWebView? = nil
-    var eventSignal: PassthroughSubject<WebViewEventType, Never>? = nil
-    var coordinator: Coordinator? = nil
+    var url: URL?
+    var webView: WKWebView?
+    var eventSignal: PassthroughSubject<WebViewEventType, Never>?
+    var coordinator: Coordinator?
     private var bag = Set<AnyCancellable>()
-    
+
     func preload(url: URL, accessToken: String) {
         if eventSignal != nil && webView != nil {
             return
@@ -39,17 +37,17 @@ class WebViewPreloadManager {
         webView?.load(URLRequest(url: url))
         bindEventSignal()
     }
-    
+
     func reload(url: URL? = nil) {
         guard let url = url ?? self.url else { return }
         webView?.load(URLRequest(url: url))
         self.url = url
     }
-    
+
     private func bindEventSignal() {
         eventSignal?.sink { [weak self] event in
             switch event {
-            case .reload(let url):
+            case let .reload(url):
                 self?.reload(url: url)
             case let .colorSchemeChange(to: colorScheme):
                 self?.webView?.setCookie(name: "theme", value: colorScheme.description)
@@ -60,20 +58,17 @@ class WebViewPreloadManager {
         }
         .store(in: &bag)
     }
-    
-    
 }
 
 extension WebViewPreloadManager {
     class Coordinator: NSObject, WKScriptMessageHandler {
-        
         let eventSignal: PassthroughSubject<WebViewEventType, Never>
-        
+
         init(eventSignal: PassthroughSubject<WebViewEventType, Never>) {
             self.eventSignal = eventSignal
         }
-        
-        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+
+        func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
             if message.name == MessageHandlerType.snutt.rawValue {
                 eventSignal.send(.close)
             }
@@ -81,8 +76,7 @@ extension WebViewPreloadManager {
     }
 }
 
-
-fileprivate enum MessageHandlerType: String {
+private enum MessageHandlerType: String {
     case snutt
     // ...
 }

--- a/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
@@ -1,0 +1,68 @@
+//
+//  ReviewState.swift
+//  SNUTT
+//
+//  Created by 박신홍 on 2022/12/26.
+//
+
+import WebKit
+import Combine
+import SwiftUI
+
+
+class ReviewState {
+    let preloadedMain = PreloadedWebView()
+    let preloadedDetail = PreloadedWebView()
+}
+
+
+class PreloadedWebView {
+    var url: URL? = nil
+    var webView: WKWebView? = nil
+    var eventSignal: PassthroughSubject<WebViewEventType, Never>? = nil
+    private var bag = Set<AnyCancellable>()
+    
+    func preload(url: URL, accessToken: String) {
+        if eventSignal != nil && webView != nil {
+            return
+        }
+        self.url = url
+        eventSignal = eventSignal ?? .init()
+        webView = webView ?? WKWebView(cookies: NetworkConfiguration.getCookiesFrom(accessToken: accessToken))
+        webView?.allowsBackForwardNavigationGestures = true
+        webView?.scrollView.bounces = false
+        webView?.backgroundColor = UIColor(STColor.systemBackground)
+        webView?.isOpaque = false
+        webView?.load(URLRequest(url: url))
+        bindEventSignal()
+    }
+    
+    func reload(url: URL? = nil) {
+        guard let url = url ?? self.url else { return }
+        webView?.load(URLRequest(url: url))
+        self.url = url
+    }
+    
+    private func bindEventSignal() {
+        eventSignal?.sink { [weak self] event in
+            switch event {
+            case .reload(let url):
+                self?.reload(url: url)
+            case let .colorSchemeChange(to: colorScheme):
+                self?.webView?.setCookie(name: "theme", value: colorScheme.description)
+                self?.webView?.evaluateJavaScript("changeTheme('\(colorScheme.description)')")
+            default:
+                return
+            }
+        }
+        .store(in: &bag)
+    }
+}
+
+enum WebViewEventType {
+    case reload(url: URL)
+    case colorSchemeChange(to: ColorScheme)
+    case close
+    case error
+    case success
+}

--- a/SNUTT-2022/SNUTT/AppState/States/UserState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/UserState.swift
@@ -11,6 +11,6 @@ class UserState: ObservableObject {
     @Published var accessToken: String?
     @Published var current: User?
 
-    /// Primary key of User. Required to logout.
+    /// Primary key of User. Required to logout. This is not `localId`.
     var userId: String?
 }

--- a/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
+++ b/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
@@ -5,8 +5,8 @@
 //  Created by 최유림 on 2022/08/24.
 //
 
-import SwiftUI
 import Foundation
+import SwiftUI
 
 struct NetworkConfiguration {
     static let serverBaseURL: String = Bundle.main.infoDictionary?["API_SERVER_URL"] as! String
@@ -19,7 +19,7 @@ struct NetworkConfiguration {
             .path: "/",
             .name: name,
             .value: value,
-            .expires: Date(timeIntervalSince1970: Date().timeIntervalSince1970 + pow(10, 9) * 2)
+            .expires: Date(timeIntervalSince1970: Date().timeIntervalSince1970 + pow(10, 9) * 2),
         ])
     }
 

--- a/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
+++ b/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
@@ -11,7 +11,7 @@ struct NetworkConfiguration {
     static let serverBaseURL: String = Bundle.main.infoDictionary?["API_SERVER_URL"] as! String
     static let snuevBaseURL: String = Bundle.main.infoDictionary?["SNUEV_WEB_URL"] as! String
     static let apiKey: String = Bundle.main.infoDictionary?["API_KEY"] as! String
-    
+
     static func getCookie(name: String, value: String) -> HTTPCookie? {
         return HTTPCookie(properties: [
             .domain: NetworkConfiguration.snuevBaseURL.replacingOccurrences(of: "https://", with: ""),
@@ -20,12 +20,12 @@ struct NetworkConfiguration {
             .value: value,
         ])
     }
-    
+
     static func getCookiesFrom(accessToken: String) -> [HTTPCookie] {
         guard let apiKeyCookie = getCookie(name: "x-access-apikey", value: NetworkConfiguration.apiKey),
               let tokenCookie = getCookie(name: "x-access-token", value: accessToken),
-                let deviceTypeCookie = getCookie(name: "x-os-type", value: AppMetadata.osType.value ?? "ios")
-              else { return [] }
+              let deviceTypeCookie = getCookie(name: "x-os-type", value: AppMetadata.osType.value ?? "ios")
+        else { return [] }
 
         return [apiKeyCookie, tokenCookie, deviceTypeCookie]
     }

--- a/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
+++ b/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
@@ -5,10 +5,27 @@
 //  Created by 최유림 on 2022/08/24.
 //
 
-import Foundation
+import SwiftUI
 
 struct NetworkConfiguration {
     static let serverBaseURL: String = Bundle.main.infoDictionary?["API_SERVER_URL"] as! String
     static let snuevBaseURL: String = Bundle.main.infoDictionary?["SNUEV_WEB_URL"] as! String
     static let apiKey: String = Bundle.main.infoDictionary?["API_KEY"] as! String
+    
+    static func getCookie(name: String, value: String) -> HTTPCookie? {
+        return HTTPCookie(properties: [
+            .domain: NetworkConfiguration.snuevBaseURL.replacingOccurrences(of: "https://", with: ""),
+            .path: "/",
+            .name: name,
+            .value: value,
+        ])
+    }
+    
+    static func getCookiesFrom(accessToken: String) -> [HTTPCookie] {
+        guard let apiKeyCookie = getCookie(name: "x-access-apikey", value: NetworkConfiguration.apiKey),
+              let tokenCookie = getCookie(name: "x-access-token", value: accessToken)
+              else { return [] }
+
+        return [apiKeyCookie, tokenCookie]
+    }
 }

--- a/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
+++ b/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Foundation
 
 struct NetworkConfiguration {
     static let serverBaseURL: String = Bundle.main.infoDictionary?["API_SERVER_URL"] as! String
@@ -18,6 +19,7 @@ struct NetworkConfiguration {
             .path: "/",
             .name: name,
             .value: value,
+            .expires: Date(timeIntervalSince1970: Date().timeIntervalSince1970 + pow(10, 9) * 2)
         ])
     }
 

--- a/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
+++ b/SNUTT-2022/SNUTT/Repositories/NetworkConfiguration.swift
@@ -23,9 +23,10 @@ struct NetworkConfiguration {
     
     static func getCookiesFrom(accessToken: String) -> [HTTPCookie] {
         guard let apiKeyCookie = getCookie(name: "x-access-apikey", value: NetworkConfiguration.apiKey),
-              let tokenCookie = getCookie(name: "x-access-token", value: accessToken)
+              let tokenCookie = getCookie(name: "x-access-token", value: accessToken),
+                let deviceTypeCookie = getCookie(name: "x-os-type", value: AppMetadata.osType.value ?? "ios")
               else { return [] }
 
-        return [apiKeyCookie, tokenCookie]
+        return [apiKeyCookie, tokenCookie, deviceTypeCookie]
     }
 }

--- a/SNUTT-2022/SNUTT/Repositories/ReviewRepository.swift
+++ b/SNUTT-2022/SNUTT/Repositories/ReviewRepository.swift
@@ -9,7 +9,7 @@ import Alamofire
 import Foundation
 
 protocol ReviewRepositoryProtocol {
-    func fetchReviewId(courseNumber: String, instructor: String) async throws -> Int
+    func fetchReviewId(courseNumber: String, instructor: String) async throws -> String
 }
 
 class ReviewRepository: ReviewRepositoryProtocol {
@@ -19,11 +19,11 @@ class ReviewRepository: ReviewRepositoryProtocol {
         self.session = session
     }
 
-    func fetchReviewId(courseNumber: String, instructor: String) async throws -> Int {
+    func fetchReviewId(courseNumber: String, instructor: String) async throws -> String {
         return try await session.request(ReviewRouter.getReviewId(courseNumber: courseNumber, instructor: instructor))
             .serializingDecodable([String: Int].self)
             .handlingError()
-            .compactMap { $0.value }
+            .compactMap { String($0.value) }
             .first!
     }
 }

--- a/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
+++ b/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
@@ -35,6 +35,10 @@ protocol GlobalUIServiceProtocol {
     func presentErrorAlert(error: STError?)
     func presentErrorAlert(error: ErrorCode)
     func presentErrorAlert(error: Error)
+    
+    func preloadWebViews()
+    func sendMainWebViewReloadSignal()
+    func sendDetailWebViewReloadSignal(url: URL)
 }
 
 struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
@@ -134,7 +138,25 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
             appState.menu.createQuarter = value
         }
     }
-
+    
+    // MARK: Preload Review WebViews
+    
+    func preloadWebViews() {
+        guard let accessToken = appState.user.accessToken else { return }
+        DispatchQueue.main.async {
+        appState.review.preloadedMain.preload(url: WebViewType.review.url, accessToken: accessToken)
+        appState.review.preloadedDetail.preload(url: WebViewType.review.url, accessToken: accessToken)
+        }
+    }
+    
+    func sendMainWebViewReloadSignal() {
+        appState.review.preloadedMain.eventSignal?.send(.reload(url: WebViewType.review.url))
+    }
+    
+    func sendDetailWebViewReloadSignal(url: URL) {
+        appState.review.preloadedDetail.eventSignal?.send(.reload(url: url))
+    }
+    
     // MARK: Lecture Time Sheet
 
     func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?) {

--- a/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
+++ b/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
@@ -35,7 +35,7 @@ protocol GlobalUIServiceProtocol {
     func presentErrorAlert(error: STError?)
     func presentErrorAlert(error: ErrorCode)
     func presentErrorAlert(error: Error)
-    
+
     func preloadWebViews()
     func sendMainWebViewReloadSignal()
     func sendDetailWebViewReloadSignal(url: URL)
@@ -138,25 +138,25 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
             appState.menu.createQuarter = value
         }
     }
-    
+
     // MARK: Preload Review WebViews
-    
+
     func preloadWebViews() {
         guard let accessToken = appState.user.accessToken else { return }
         DispatchQueue.main.async {
-        appState.review.preloadedMain.preload(url: WebViewType.review.url, accessToken: accessToken)
-        appState.review.preloadedDetail.preload(url: WebViewType.review.url, accessToken: accessToken)
+            appState.review.preloadedMain.preload(url: WebViewType.review.url, accessToken: accessToken)
+            appState.review.preloadedDetail.preload(url: WebViewType.review.url, accessToken: accessToken)
         }
     }
-    
+
     func sendMainWebViewReloadSignal() {
         appState.review.preloadedMain.eventSignal?.send(.reload(url: WebViewType.review.url))
     }
-    
+
     func sendDetailWebViewReloadSignal(url: URL) {
         appState.review.preloadedDetail.eventSignal?.send(.reload(url: url))
     }
-    
+
     // MARK: Lecture Time Sheet
 
     func setIsLectureTimeSheetOpen(_ value: Bool, modifying timePlace: TimePlace?, action: ((TimePlace) -> Void)?) {

--- a/SNUTT-2022/SNUTT/Services/LectureService.swift
+++ b/SNUTT-2022/SNUTT/Services/LectureService.swift
@@ -14,7 +14,7 @@ protocol LectureServiceProtocol {
     func updateLecture(oldLecture: Lecture, newLecture: Lecture, isForced: Bool) async throws
     func deleteLecture(lecture: Lecture) async throws
     func resetLecture(lecture: Lecture) async throws
-    func fetchReviewId(courseNumber: String, instructor: String, bind: Binding<String>) async throws
+    func fetchReviewId(courseNumber: String, instructor: String) async throws -> String
 }
 
 extension LectureServiceProtocol {
@@ -99,9 +99,8 @@ struct LectureService: LectureServiceProtocol {
         userDefaultsRepository.set(TimetableDto.self, key: .currentTimetable, value: dto)
     }
 
-    func fetchReviewId(courseNumber: String, instructor: String, bind: Binding<String>) async throws {
-        let id = try await reviewRepository.fetchReviewId(courseNumber: courseNumber, instructor: instructor)
-        bind.wrappedValue = "\(id)"
+    func fetchReviewId(courseNumber: String, instructor: String) async throws -> String {
+        return try await reviewRepository.fetchReviewId(courseNumber: courseNumber, instructor: instructor)
     }
 
     private var lectureRepository: LectureRepositoryProtocol {
@@ -123,5 +122,5 @@ class FakeLectureService: LectureServiceProtocol {
     func addLecture(lecture _: Lecture, isForced _: Bool) async throws {}
     func deleteLecture(lecture _: Lecture) async throws {}
     func resetLecture(lecture _: Lecture) async throws {}
-    func fetchReviewId(courseNumber _: String, instructor _: String, bind _: Binding<String>) async throws {}
+    func fetchReviewId(courseNumber: String, instructor: String) async throws -> String { return "" }
 }

--- a/SNUTT-2022/SNUTT/Services/LectureService.swift
+++ b/SNUTT-2022/SNUTT/Services/LectureService.swift
@@ -122,5 +122,5 @@ class FakeLectureService: LectureServiceProtocol {
     func addLecture(lecture _: Lecture, isForced _: Bool) async throws {}
     func deleteLecture(lecture _: Lecture) async throws {}
     func resetLecture(lecture _: Lecture) async throws {}
-    func fetchReviewId(courseNumber: String, instructor: String) async throws -> String { return "" }
+    func fetchReviewId(courseNumber _: String, instructor _: String) async throws -> String { return "" }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -98,12 +98,13 @@ extension LectureDetailScene {
             return nil
         }
 
-        func fetchReviewId(of lecture: Lecture, bind: Binding<String>) async {
+        func fetchReviewId(of lecture: Lecture) async -> String? {
             do {
-                try await lectureService.fetchReviewId(courseNumber: lecture.courseNumber, instructor: lecture.instructor, bind: bind)
+                return try await lectureService.fetchReviewId(courseNumber: lecture.courseNumber, instructor: lecture.instructor)
             } catch {
                 services.globalUIService.presentErrorAlert(error: error)
             }
+            return nil
         }
 
         func fetchSyllabusURL(of lecture: Lecture) async -> String {
@@ -143,6 +144,11 @@ extension LectureDetailScene {
                 return nil
             }
             return lecture
+        }
+        
+        func reloadDetailWebView(detailId: String?) {
+            guard let detailId = detailId else { return }
+            services.globalUIService.sendDetailWebViewReloadSignal(url: WebViewType.reviewDetail(id: detailId).url)
         }
     }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -145,7 +145,7 @@ extension LectureDetailScene {
             }
             return lecture
         }
-        
+
         func reloadDetailWebView(detailId: String?) {
             guard let detailId = detailId else { return }
             services.globalUIService.sendDetailWebViewReloadSignal(url: WebViewType.reviewDetail(id: detailId).url)

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -141,7 +141,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
             services.globalUIService.presentErrorAlert(error: error)
         }
     }
-    
+
     func preloadReviewWebView(reviewId: String) {
         services.globalUIService.sendDetailWebViewReloadSignal(url: WebViewType.reviewDetail(id: reviewId).url)
     }

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -141,6 +141,10 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
             services.globalUIService.presentErrorAlert(error: error)
         }
     }
+    
+    func preloadReviewWebView(reviewId: String) {
+        services.globalUIService.sendDetailWebViewReloadSignal(url: WebViewType.reviewDetail(id: reviewId).url)
+    }
 
     private var searchState: SearchState {
         appState.search

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -125,12 +125,13 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         timetableState.current?.lectures.first(where: { $0.isEquivalent(with: lecture) })
     }
 
-    func fetchReviewId(of lecture: Lecture, bind: Binding<String>) async {
+    func fetchReviewId(of lecture: Lecture) async -> String? {
         do {
-            try await services.lectureService.fetchReviewId(courseNumber: lecture.courseNumber, instructor: lecture.instructor, bind: bind)
+            return try await services.lectureService.fetchReviewId(courseNumber: lecture.courseNumber, instructor: lecture.instructor)
         } catch {
             services.globalUIService.presentErrorAlert(error: error)
         }
+        return nil
     }
 
     func overwriteLecture(lecture: Lecture) async {

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -108,4 +108,8 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
     private var timetableState: TimetableState {
         appState.timetable
     }
+    
+    func preloadWebViews() {
+        services.globalUIService.preloadWebViews()
+    }
 }

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -108,7 +108,7 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
     private var timetableState: TimetableState {
         appState.timetable
     }
-    
+
     func preloadWebViews() {
         services.globalUIService.preloadWebViews()
     }

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -12,12 +12,12 @@ struct SearchLectureCell: View {
     let selected: Bool
     let addLecture: (Lecture) async -> Void
     let deleteLecture: (Lecture) async -> Void
-    let fetchReviewId: (Lecture, Binding<String>) async -> Void
+    let fetchReviewId: (Lecture) async -> String?
     let isInTimetable: Bool
 
     @State var showingDetailPage = false
     @State private var showReviewWebView: Bool = false
-    @State private var reviewId: String = ""
+    @State private var reviewId: String? = ""
 
     @Environment(\.dependencyContainer) var container: DIContainer?
 
@@ -57,7 +57,7 @@ struct SearchLectureCell: View {
 
                         Button {
                             Task {
-                                await fetchReviewId(lecture, $reviewId)
+                                reviewId = await fetchReviewId(lecture)
                                 showReviewWebView = true
                             }
                         } label: {

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -17,8 +17,8 @@ struct SearchLectureCell: View {
 
     @State var showingDetailPage = false
     @State private var showReviewWebView: Bool = false
-    @State private var reviewId: String? = ""
-
+    @State private var reviewId: String? = nil
+    
     @Environment(\.dependencyContainer) var container: DIContainer?
 
     var body: some View {
@@ -59,6 +59,11 @@ struct SearchLectureCell: View {
                             Task {
                                 reviewId = await fetchReviewId(lecture)
                                 showReviewWebView = true
+                                
+                                // TODO: fix me
+                                if let detailId = reviewId {
+                                    container?.services.globalUIService.sendDetailWebViewReloadSignal(url: WebViewType.reviewDetail(id: detailId).url)
+                                }
                             }
                         } label: {
                             Text("강의평")
@@ -68,6 +73,7 @@ struct SearchLectureCell: View {
                         .sheet(isPresented: $showReviewWebView) {
                             if let container = container {
                                 ReviewScene(viewModel: .init(container: container), detailId: $reviewId)
+                                    .id(reviewId)
                             }
                         }
 

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -70,12 +70,6 @@ struct SearchLectureCell: View {
                                 .frame(maxWidth: .infinity)
                                 .font(STFont.details)
                         }
-                        .sheet(isPresented: $showReviewWebView) {
-                            if let container = container {
-                                ReviewScene(viewModel: .init(container: container), detailId: $reviewId)
-                                    .id(reviewId)
-                            }
-                        }
 
                         if isInTimetable {
                             Button {
@@ -100,6 +94,12 @@ struct SearchLectureCell: View {
                         }
                     }
                     /// This `sheet` modifier should be called on `HStack` to prevent animation glitch when `dismiss`ed.
+                    .sheet(isPresented: $showReviewWebView) {
+                        if let container = container {
+                            ReviewScene(viewModel: .init(container: container), detailId: $reviewId)
+                                .id(reviewId)
+                        }
+                    }
                     .sheet(isPresented: $showingDetailPage) {
                         if let container = container {
                             NavigationView {
@@ -107,6 +107,7 @@ struct SearchLectureCell: View {
                             }
                         }
                     }
+                    
                 }
             }
             .foregroundColor(.white)

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -18,7 +18,7 @@ struct SearchLectureCell: View {
     @State var showingDetailPage = false
     @State private var showReviewWebView: Bool = false
     @State private var reviewId: String? = nil
-    
+
     @Environment(\.dependencyContainer) var container: DIContainer?
 
     var body: some View {
@@ -59,7 +59,7 @@ struct SearchLectureCell: View {
                             Task {
                                 reviewId = await fetchReviewId(lecture)
                                 showReviewWebView = true
-                                
+
                                 // TODO: fix me
                                 if let detailId = reviewId {
                                     container?.services.globalUIService.sendDetailWebViewReloadSignal(url: WebViewType.reviewDetail(id: detailId).url)
@@ -107,7 +107,6 @@ struct SearchLectureCell: View {
                             }
                         }
                     }
-                    
                 }
             }
             .foregroundColor(.white)

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -13,6 +13,7 @@ struct SearchLectureCell: View {
     let addLecture: (Lecture) async -> Void
     let deleteLecture: (Lecture) async -> Void
     let fetchReviewId: (Lecture) async -> String?
+    let preloadReviewWebView: (String) -> Void
     let isInTimetable: Bool
 
     @State var showingDetailPage = false
@@ -58,11 +59,9 @@ struct SearchLectureCell: View {
                         Button {
                             Task {
                                 reviewId = await fetchReviewId(lecture)
-                                showReviewWebView = true
-
-                                // TODO: fix me
                                 if let detailId = reviewId {
-                                    container?.services.globalUIService.sendDetailWebViewReloadSignal(url: WebViewType.reviewDetail(id: detailId).url)
+                                    preloadReviewWebView(detailId)
+                                    showReviewWebView = true
                                 }
                             }
                         } label: {

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
@@ -13,7 +13,7 @@ struct SearchLectureList: View {
     let existingLecture: (Lecture) -> Lecture?
     let addLecture: (Lecture) async -> Void
     let deleteLecture: (Lecture) async -> Void
-    let fetchReviewId: (Lecture, Binding<String>) async -> Void
+    let fetchReviewId: (Lecture) async -> String?
     let overwriteLecture: (Lecture) async -> Void
     let errorTitle: String
     let errorMessage: String

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureList.swift
@@ -15,6 +15,7 @@ struct SearchLectureList: View {
     let deleteLecture: (Lecture) async -> Void
     let fetchReviewId: (Lecture) async -> String?
     let overwriteLecture: (Lecture) async -> Void
+    let preloadReviewWebView: (String) -> Void
     let errorTitle: String
     let errorMessage: String
     @Binding var isLectureOverlapped: Bool
@@ -29,6 +30,7 @@ struct SearchLectureList: View {
                                       addLecture: addLecture,
                                       deleteLecture: deleteLecture,
                                       fetchReviewId: fetchReviewId,
+                                      preloadReviewWebView: preloadReviewWebView,
                                       isInTimetable: existingLecture(lecture) != nil)
                         .task {
                             if lecture.id == data.last?.id {

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/ReviewWebView.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/ReviewWebView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import WebKit
 
 struct ReviewWebView: UIViewRepresentable {
-    var preloadWebView: PreloadedWebView
+    var preloadWebView: WebViewPreloadManager
     
     var webView: WKWebView {
         preloadWebView.webView!
@@ -20,12 +20,13 @@ struct ReviewWebView: UIViewRepresentable {
         preloadWebView.eventSignal!
     }
 
-    init(preloadedWebView: PreloadedWebView) {
+    init(preloadedWebView: WebViewPreloadManager) {
         self.preloadWebView = preloadedWebView
     }
 
     func makeUIView(context: Context) -> WKWebView {
         webView.navigationDelegate = context.coordinator
+        
         return webView
     }
 
@@ -37,24 +38,28 @@ struct ReviewWebView: UIViewRepresentable {
         Coordinator(self)
     }
 
-    class Coordinator: NSObject, WKNavigationDelegate {
+    class Coordinator: NSObject {
         let parent: ReviewWebView
 
         init(_ parent: ReviewWebView) {
             self.parent = parent
             super.init()
         }
-
-        func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
-            parent.eventSignal.send(.error)
-        }
-
-        func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
-            parent.eventSignal.send(.error)
-        }
-
-        func webView(_: WKWebView, didFinish _: WKNavigation!) {
-            parent.eventSignal.send(.success)
-        }
     }
 }
+
+
+extension ReviewWebView.Coordinator: WKNavigationDelegate {
+    func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
+        parent.eventSignal.send(.error)
+    }
+
+    func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+        parent.eventSignal.send(.error)
+    }
+
+    func webView(_: WKWebView, didFinish _: WKNavigation!) {
+        parent.eventSignal.send(.success)
+    }
+}
+

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/ReviewWebView.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/ReviewWebView.swift
@@ -11,22 +11,22 @@ import WebKit
 
 struct ReviewWebView: UIViewRepresentable {
     var preloadWebView: WebViewPreloadManager
-    
+
     var webView: WKWebView {
         preloadWebView.webView!
     }
-    
+
     var eventSignal: PassthroughSubject<WebViewEventType, Never> {
         preloadWebView.eventSignal!
     }
 
     init(preloadedWebView: WebViewPreloadManager) {
-        self.preloadWebView = preloadedWebView
+        preloadWebView = preloadedWebView
     }
 
     func makeUIView(context: Context) -> WKWebView {
         webView.navigationDelegate = context.coordinator
-        
+
         return webView
     }
 
@@ -48,7 +48,6 @@ struct ReviewWebView: UIViewRepresentable {
     }
 }
 
-
 extension ReviewWebView.Coordinator: WKNavigationDelegate {
     func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
         parent.eventSignal.send(.error)
@@ -62,4 +61,3 @@ extension ReviewWebView.Coordinator: WKNavigationDelegate {
         parent.eventSignal.send(.success)
     }
 }
-

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/ReviewWebView.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/ReviewWebView.swift
@@ -9,31 +9,23 @@ import Combine
 import SwiftUI
 import WebKit
 
-struct ReviewWebView: WebView {
-    var url: URL
-    let accessToken: String
-    @Binding var connectionState: WebViewConnectionState
+struct ReviewWebView: UIViewRepresentable {
+    var preloadWebView: PreloadedWebView
+    
+    var webView: WKWebView {
+        preloadWebView.webView!
+    }
+    
+    var eventSignal: PassthroughSubject<WebViewEventType, Never> {
+        preloadWebView.eventSignal!
+    }
 
-    /// An event stream used to control `WKWebView` instance outside current view.
-    var eventSignal: PassthroughSubject<WebViewEventType, Never>
-
-    var webView: WKWebView
-
-    init(url: URL, accessToken: String, connectionState: Binding<WebViewConnectionState>, eventSignal: PassthroughSubject<WebViewEventType, Never>, initialColorScheme: ColorScheme) {
-        self.url = url
-        self.accessToken = accessToken
-        _connectionState = connectionState
-        self.eventSignal = eventSignal
-        webView = WKWebView(cookies: ReviewWebView.getCookiesFrom(accessToken: accessToken, colorScheme: initialColorScheme))
+    init(preloadedWebView: PreloadedWebView) {
+        self.preloadWebView = preloadedWebView
     }
 
     func makeUIView(context: Context) -> WKWebView {
         webView.navigationDelegate = context.coordinator
-        webView.allowsBackForwardNavigationGestures = true
-        webView.scrollView.bounces = false
-        webView.load(urlRequest)
-        webView.backgroundColor = UIColor(STColor.systemBackground)
-        webView.isOpaque = false
         return webView
     }
 
@@ -45,61 +37,24 @@ struct ReviewWebView: WebView {
         Coordinator(self)
     }
 
-    private static func getCookie(name: String, value: String) -> HTTPCookie? {
-        return HTTPCookie(properties: [
-            .domain: NetworkConfiguration.snuevBaseURL.replacingOccurrences(of: "https://", with: ""),
-            .path: "/",
-            .name: name,
-            .value: value,
-        ])
-    }
-
-    private static func getCookiesFrom(accessToken: String, colorScheme: ColorScheme) -> [HTTPCookie] {
-        guard let apiKeyCookie = getCookie(name: "x-access-apikey", value: NetworkConfiguration.apiKey),
-              let tokenCookie = getCookie(name: "x-access-token", value: accessToken),
-              let themeCookie = getCookie(name: "theme", value: colorScheme.description) else { return [] }
-
-        return [apiKeyCookie, tokenCookie, themeCookie]
-    }
-
-    func reloadWebView() {
-        webView.load(urlRequest)
-    }
-
     class Coordinator: NSObject, WKNavigationDelegate {
         let parent: ReviewWebView
-        private var bag = Set<AnyCancellable>()
 
         init(_ parent: ReviewWebView) {
             self.parent = parent
             super.init()
-
-            self.parent.eventSignal.sink { [weak self] event in
-                switch event {
-                case .reload:
-                    self?.parent.reloadWebView()
-                case let .colorSchemeChange(to: colorScheme):
-                    self?.parent.webView.evaluateJavaScript("changeTheme('\(colorScheme.description)')")
-                }
-            }.store(in: &bag)
         }
 
         func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
-            if parent.connectionState == .success {
-                parent.connectionState = .error
-            }
+            parent.eventSignal.send(.error)
         }
 
         func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
-            if parent.connectionState == .success {
-                parent.connectionState = .error
-            }
+            parent.eventSignal.send(.error)
         }
 
         func webView(_: WKWebView, didFinish _: WKNavigation!) {
-            if parent.connectionState == .error {
-                parent.connectionState = .success
-            }
+            parent.eventSignal.send(.success)
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
@@ -32,9 +32,9 @@ extension WKWebView {
         configuration.websiteDataStore = dataStore
         self.init(frame: .zero, configuration: configuration)
     }
-    
-    func setCookie(name:String, value: String) {
+
+    func setCookie(name: String, value: String) {
         guard let cookie = NetworkConfiguration.getCookie(name: name, value: value) else { return }
-        self.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+        configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
@@ -32,4 +32,9 @@ extension WKWebView {
         configuration.websiteDataStore = dataStore
         self.init(frame: .zero, configuration: configuration)
     }
+    
+    func setCookie(name:String, value: String) {
+        guard let cookie = NetworkConfiguration.getCookie(name: name, value: value) else { return }
+        self.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+    }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewType.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewType.swift
@@ -39,7 +39,7 @@ enum WebViewType {
         case .review:
             return ""
         case let .reviewDetail(id):
-            return "/detail/?id=\(id)"
+            return "/detail/?id=\(id)&on_back=close"
         }
     }
 

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -53,18 +53,15 @@ struct SNUTTView: View {
                         SettingScene(viewModel: .init(container: viewModel.container))
                     }
                 }
-                .onAppear {
-                    selectedTab = .timetable
-                }
                 if selectedTab == .timetable {
                     MenuSheetScene(viewModel: .init(container: viewModel.container))
+                    LectureTimeSheetScene(viewModel: .init(container: viewModel.container))
                 }
                 if selectedTab == .search {
                     FilterSheetScene(viewModel: .init(container: viewModel.container))
                 }
                 PopupScene(viewModel: .init(container: viewModel.container))
             }
-            LectureTimeSheetScene(viewModel: .init(container: viewModel.container))
         }
         .animation(.easeOut, value: viewModel.accessToken)
         .preferredColorScheme(viewModel.preferredColorScheme)

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -47,7 +47,7 @@ struct SNUTTView: View {
                         SearchLectureScene(viewModel: .init(container: viewModel.container), navigationBarHeight: navigationBarHeight)
                     }
                     TabScene(tabType: .review) {
-                        ReviewScene(viewModel: .init(container: viewModel.container), webViewEventSignal: viewModel.reviewEventSignal)
+                        ReviewScene(viewModel: .init(container: viewModel.container))
                     }
                     TabScene(tabType: .settings) {
                         SettingScene(viewModel: .init(container: viewModel.container))
@@ -99,9 +99,7 @@ extension SNUTTView {
         @Published var isErrorAlertPresented = false
         @Published var accessToken: String? = nil
         @Published var preferredColorScheme: ColorScheme? = nil
-
         @Published private var error: STError? = nil
-        var reviewEventSignal = PassthroughSubject<WebViewEventType, Never>()
 
         var isAuthenticated: Bool {
             guard let accessToken = accessToken else { return false }
@@ -125,7 +123,7 @@ extension SNUTTView {
         }
 
         func reloadReviewWebView() {
-            reviewEventSignal.send(.reload)
+            services.globalUIService.sendMainWebViewReloadSignal()
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -32,7 +32,7 @@ struct LectureDetailScene: View {
     @State private var isResetAlertPresented = false
     @State private var isDeleteAlertPresented = false
     @State private var showReviewWebView = false
-    @State private var reviewId: String = ""
+    @State private var reviewId: String? = ""
     @State private var syllabusURL: String = ""
     @State private var showSyllabusWebView = false
 
@@ -196,13 +196,18 @@ struct LectureDetailScene: View {
 
                         DetailButton(text: "강의평") {
                             Task {
-                                await viewModel.fetchReviewId(of: lecture, bind: $reviewId)
+                                reviewId = await viewModel.fetchReviewId(of: lecture)
                                 showReviewWebView = true
                             }
                         }
                         .sheet(isPresented: $showReviewWebView) {
                             ReviewScene(viewModel: .init(container: viewModel.container), detailId: $reviewId)
                                 .id(colorScheme)
+                                .id(reviewId)
+                        }
+                        .onChange(of: reviewId) { newValue in
+                            guard let reviewId = newValue else { return }
+                            viewModel.reloadDetailWebView(detailId: reviewId)
                         }
                     }
 

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -195,19 +195,21 @@ struct LectureDetailScene: View {
                         }
 
                         DetailButton(text: "강의평") {
+                            showReviewWebView = true
+                        }
+                        .onAppear {
                             Task {
                                 reviewId = await viewModel.fetchReviewId(of: lecture)
-                                showReviewWebView = true
                             }
+                        }
+                        .onChange(of: reviewId) { newValue in
+                            guard let reviewId = newValue else { return }
+                            viewModel.reloadDetailWebView(detailId: reviewId)
                         }
                         .sheet(isPresented: $showReviewWebView) {
                             ReviewScene(viewModel: .init(container: viewModel.container), detailId: $reviewId)
                                 .id(colorScheme)
                                 .id(reviewId)
-                        }
-                        .onChange(of: reviewId) { newValue in
-                            guard let reviewId = newValue else { return }
-                            viewModel.reloadDetailWebView(detailId: reviewId)
                         }
                     }
 

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -8,27 +8,29 @@
 import Combine
 import SwiftUI
 
-enum WebViewEventType {
-    case reload
-    case colorSchemeChange(to: ColorScheme)
-}
+
 
 struct ReviewScene: View {
     @ObservedObject var viewModel: ViewModel
-    @Binding var detailId: String
-
-    var eventSignal: PassthroughSubject<WebViewEventType, Never>
+    @Binding var detailId: String?
 
     @Environment(\.colorScheme) var colorScheme
 
-    init(viewModel: ViewModel, detailId: Binding<String> = .constant(""), webViewEventSignal: PassthroughSubject<WebViewEventType, Never>? = nil) {
+    init(viewModel: ViewModel, detailId: Binding<String?>? = nil) {
         self.viewModel = viewModel
-        _detailId = detailId
-        eventSignal = webViewEventSignal ?? .init()
+        if let detailId = detailId {
+            self._detailId = detailId
+        } else {
+            self._detailId = .constant(nil)
+        }
     }
-
+    
+    private var eventSignal: PassthroughSubject<WebViewEventType, Never>? {
+        viewModel.getPreloadedWebView(detailId: detailId).eventSignal
+    }
+    
     private var reviewUrl: URL {
-        if !detailId.isEmpty {
+        if let detailId = detailId {
             return WebViewType.reviewDetail(id: detailId).url
         } else {
             return WebViewType.review.url
@@ -37,14 +39,14 @@ struct ReviewScene: View {
 
     var body: some View {
         ZStack {
-            ReviewWebView(url: reviewUrl, accessToken: viewModel.accessToken, connectionState: $viewModel.connectionState, eventSignal: eventSignal, initialColorScheme: colorScheme)
+            ReviewWebView(preloadedWebView: viewModel.getPreloadedWebView(detailId: detailId))
                 .navigationBarHidden(true)
                 .edgesIgnoringSafeArea(.bottom)
                 .background(STColor.systemBackground)
 
             if viewModel.connectionState == .error {
                 WebErrorView(refresh: {
-                    eventSignal.send(.reload)
+                    eventSignal?.send(.reload(url: reviewUrl))
                 })
                 .navigationTitle("강의평")
                 .navigationBarTitleDisplayMode(.inline)
@@ -52,8 +54,21 @@ struct ReviewScene: View {
                 .background(STColor.systemBackground)
             }
         }
+        .onAppear {
+            eventSignal?.send(.colorSchemeChange(to: colorScheme))
+        }
         .onChange(of: colorScheme) { newValue in
-            eventSignal.send(.colorSchemeChange(to: newValue))
+            eventSignal?.send(.colorSchemeChange(to: newValue))
+        }
+        .onReceive(eventSignal ?? .init()) { signal in
+            switch signal {
+            case .success:
+                viewModel.connectionState = .success
+            case .error:
+                viewModel.connectionState = .error
+            default:
+                return
+            }
         }
 
         let _ = debugChanges()
@@ -78,6 +93,14 @@ extension ReviewScene {
                     self.accessToken = ""
                 }
             }.store(in: &bag)
+        }
+        
+        func getPreloadedWebView(detailId: String?) -> PreloadedWebView {
+            if detailId == nil {
+                return appState.review.preloadedMain
+            } else {
+                return appState.review.preloadedDetail
+            }
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -15,6 +15,7 @@ struct ReviewScene: View {
     @Binding var detailId: String?
 
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.dismiss) var dismiss
 
     init(viewModel: ViewModel, detailId: Binding<String?>? = nil) {
         self.viewModel = viewModel
@@ -66,6 +67,8 @@ struct ReviewScene: View {
                 viewModel.connectionState = .success
             case .error:
                 viewModel.connectionState = .error
+            case .close:
+                dismiss()
             default:
                 return
             }
@@ -95,7 +98,7 @@ extension ReviewScene {
             }.store(in: &bag)
         }
         
-        func getPreloadedWebView(detailId: String?) -> PreloadedWebView {
+        func getPreloadedWebView(detailId: String?) -> WebViewPreloadManager {
             if detailId == nil {
                 return appState.review.preloadedMain
             } else {

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -8,8 +8,6 @@
 import Combine
 import SwiftUI
 
-
-
 struct ReviewScene: View {
     @ObservedObject var viewModel: ViewModel
     @Binding var detailId: String?
@@ -20,16 +18,16 @@ struct ReviewScene: View {
     init(viewModel: ViewModel, detailId: Binding<String?>? = nil) {
         self.viewModel = viewModel
         if let detailId = detailId {
-            self._detailId = detailId
+            _detailId = detailId
         } else {
-            self._detailId = .constant(nil)
+            _detailId = .constant(nil)
         }
     }
-    
+
     private var eventSignal: PassthroughSubject<WebViewEventType, Never>? {
         viewModel.getPreloadedWebView(detailId: detailId).eventSignal
     }
-    
+
     private var reviewUrl: URL {
         if let detailId = detailId {
             return WebViewType.reviewDetail(id: detailId).url
@@ -97,7 +95,7 @@ extension ReviewScene {
                 }
             }.store(in: &bag)
         }
-        
+
         func getPreloadedWebView(detailId: String?) -> WebViewPreloadManager {
             if detailId == nil {
                 return appState.review.preloadedMain

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -15,13 +15,9 @@ struct ReviewScene: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
 
-    init(viewModel: ViewModel, detailId: Binding<String?>? = nil) {
+    init(viewModel: ViewModel, detailId: Binding<String?> = .constant(nil)) {
         self.viewModel = viewModel
-        if let detailId = detailId {
-            _detailId = detailId
-        } else {
-            _detailId = .constant(nil)
-        }
+        _detailId = detailId
     }
 
     private var eventSignal: PassthroughSubject<WebViewEventType, Never>? {

--- a/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
@@ -65,7 +65,7 @@ struct SearchLectureScene: View {
                                           existingLecture: viewModel.getExistingLecture,
                                           addLecture: viewModel.addLecture,
                                           deleteLecture: viewModel.deleteLecture,
-                                          fetchReviewId: viewModel.fetchReviewId(of:bind:),
+                                          fetchReviewId: viewModel.fetchReviewId(of:),
                                           overwriteLecture: viewModel.overwriteLecture(lecture:),
                                           errorTitle: viewModel.errorTitle,
                                           errorMessage: viewModel.errorMessage,

--- a/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
@@ -67,6 +67,7 @@ struct SearchLectureScene: View {
                                           deleteLecture: viewModel.deleteLecture,
                                           fetchReviewId: viewModel.fetchReviewId(of:),
                                           overwriteLecture: viewModel.overwriteLecture(lecture:),
+                                          preloadReviewWebView: viewModel.preloadReviewWebView(reviewId:),
                                           errorTitle: viewModel.errorTitle,
                                           errorMessage: viewModel.errorMessage,
                                           isLectureOverlapped: $viewModel.isLectureOverlapped,

--- a/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
@@ -70,7 +70,8 @@ struct TimetableScene: View {
                     ActivityViewController(activityItems: [screenshot, linkMetadata])
                 }
                 .onLoad {
-                    // make the following three api calls execute concurrently
+                    viewModel.preloadWebViews()
+                    
                     await withTaskGroup(of: Void.self, body: { group in
                         group.addTask {
                             await viewModel.fetchTimetableList()

--- a/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
@@ -71,7 +71,7 @@ struct TimetableScene: View {
                 }
                 .onLoad {
                     viewModel.preloadWebViews()
-                    
+
                     await withTaskGroup(of: Void.self, body: { group in
                         group.addTask {
                             await viewModel.fetchTimetableList()


### PR DESCRIPTION
- 웹뷰를 Preloading함으로써 웹뷰가 뜨는 체감 속도를 최대한 높여보았습니다.
- WebView과 관련 객체들을 전역 AppState로 옮겼으며, `WebViewPreloadManager` 객체가 이를 관리하도록 했습니다. (물론 더 나은 이름이 있다면 제안받습니다.)
    - 메인 웹뷰 하나, 디테일 웹뷰 하나 이렇게 총 두개의 `WebViewPreloadManager`가 존재합니다.
    - 검색 화면에서 디테일 웹뷰를 열 때 다른 화면이 순간적으로 보이는 문제가 있습니다. 네이티브쪽 문제도 있는데, 웹뷰쪽에서 해결이 가능한 부분도 있는 것 같습니다(아래 영상 참고).
- 디테일 웹뷰를 dismiss하는 bridge를 연결했습니다.
- 쿠키 날라가는 문제에 도움이 될까 싶어서 cookie expire date를 설정해주었습니다.

# Before (w/o preloading)

https://user-images.githubusercontent.com/33917774/209569178-bc8cd01f-ea05-4e6d-af84-a1b02ecfd772.MP4

# After (w/ preloading)

https://user-images.githubusercontent.com/33917774/209569182-61e38b18-7d4f-4df6-9367-277c052aaa96.MP4

## After (검색 화면에서 디테일 화면 진입시 글리치)

https://user-images.githubusercontent.com/33917774/209569437-e310f709-98d7-46e3-ab1f-7a4a03059a96.MP4

- @woohm402 이 부분은 웹뷰에서 처리가 가능할 것 같은데, 한번 봐주실 수 있나요?

# Known issue

- iOS 버그로 인해 Sheet을 내린 후에 재빨리 swipe back 제스쳐를 하면 앱 전체가 프리징됩니다. (https://stackoverflow.com/questions/71714592/sheet-dismiss-gesture-with-swipe-back-gesture-causes-app-to-freeze)
