### PR TITLE
Authenticate API requests for git release notes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       APP_STORE_CONNECT_KEY_ISSUER: ${{ secrets.APP_STORE_CONNECT_KEY_ISSUER }}
       APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      GIT_PAT_READONLY: ${{ secrets.GIT_PAT_READONLY }}
       GIT_TAG_NAME: ${{ github.ref_name }}
       XCODE_VERSION: '14.1'
 

--- a/SNUTT-2022/fastlane/Fastfile
+++ b/SNUTT-2022/fastlane/Fastfile
@@ -28,6 +28,7 @@ VERSION_NUMBER = ENV['VERSION_NUMBER'] || "3.0.0"
 BUILD_NUMBER = ENV['BUILD_NUMBER'] || "3"
 GIT_TAG_NAME = ENV['GIT_TAG_NAME']
 SLACK_WEBHOOK = ENV['SLACK_WEBHOOK']
+GIT_PAT_READONLY = ENV['GIT_PAT_READONLY']
 
 platform :ios do
   desc "🧪 Upload app to Testflight"
@@ -75,6 +76,7 @@ platform :ios do
   desc "📱 Upload app to App Store"
   lane :release do
     begin
+      release = get_github_release(url: "wafflestudio/snutt-ios", version: GIT_TAG_NAME, api_token: GIT_PAT_READONLY)
       setup_ci
       certificates_distribution
       increment_version_number_in_xcodeproj(version_number: VERSION_NUMBER)
@@ -90,7 +92,6 @@ platform :ios do
         issuer_id: APP_STORE_CONNECT_KEY_ISSUER,
         key_content: KEY_CONTENT,
       )
-      release = get_github_release(url: "wafflestudio/snutt-ios", version: GIT_TAG_NAME)
       upload_to_app_store(
           force: true,
           app_version: VERSION_NUMBER,


### PR DESCRIPTION
- release note를 fetching할 때에 CI서버에서 rate limit에 걸리는 경우가 많아 일단 제 개인 PAT를 secret에 추가했습니다. 아무 scope도 추가하지 않아서 public 정보에 대한 read-only access밖에 없긴 합니다.