### PR TITLE
이메일 미인증시 CTA 개선

### DIFF
--- a/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
@@ -22,11 +22,8 @@ class WebViewPreloadManager {
     private var bag = Set<AnyCancellable>()
 
     func preload(url: URL, accessToken: String) {
-        if eventSignal != nil && webView != nil {
-            return
-        }
         eventSignal = eventSignal ?? .init()
-        webView = webView ?? WKWebView(cookies: NetworkConfiguration.getCookiesFrom(accessToken: accessToken))
+        webView = WKWebView(cookies: NetworkConfiguration.getCookiesFrom(accessToken: accessToken))
         coordinator = coordinator ?? Coordinator(eventSignal: eventSignal!)
         webView?.scrollView.bounces = false
         webView?.backgroundColor = UIColor(STColor.systemBackground)

--- a/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
@@ -13,6 +13,6 @@ class SystemState: ObservableObject {
     @Published var isErrorAlertPresented = false
     @Published var error: STError? = nil
     @Published var preferredColorScheme: ColorScheme? = nil
-    
+
     @Published var selectedTab: TabType = .timetable
 }

--- a/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
@@ -13,4 +13,6 @@ class SystemState: ObservableObject {
     @Published var isErrorAlertPresented = false
     @Published var error: STError? = nil
     @Published var preferredColorScheme: ColorScheme? = nil
+    
+    @Published var selectedTab: TabType = .timetable
 }

--- a/SNUTT-2022/SNUTT/Models/ErrorCode.swift
+++ b/SNUTT-2022/SNUTT/Models/ErrorCode.swift
@@ -116,9 +116,10 @@ enum ErrorCode: Int {
              .NO_EMAIL,
              .NO_PASSWORD_RESET_REQUEST,
              .CANT_CHANGE_OTHERS_THEME,
-             .EMAIL_NOT_VERIFIED,
              .EXPIRED_PASSWORD_RESET_CODE:
             return "요청 실패"
+        case .EMAIL_NOT_VERIFIED:
+            return "인증 필요"
         case .NO_USER_TOKEN,
              .WRONG_API_KEY,
              .WRONG_USER_TOKEN,
@@ -276,7 +277,7 @@ enum ErrorCode: Int {
         case .WRONG_APPLE_TOKEN:
             return "애플 계정으로 로그인하지 못했습니다."
         case .EMAIL_NOT_VERIFIED:
-            return "인증되지 않은 이메일입니다. 강의평 탭에서 이메일 인증을 먼저 진행해주세요."
+            return "강의평 확인을 위해 이메일 인증이 필요합니다. 이메일 인증을 진행하시겠습니까?"
         case .NO_PASSWORD_RESET_REQUEST:
             return "비밀번호 재설정을 다시 시도해주세요."
         case .EXPIRED_PASSWORD_RESET_CODE:

--- a/SNUTT-2022/SNUTT/Services/AuthService.swift
+++ b/SNUTT-2022/SNUTT/Services/AuthService.swift
@@ -127,7 +127,9 @@ extension UserAuthHandler {
             appState.user.accessToken = nil
             appState.user.userId = nil
             appState.user.current = nil
+            appState.timetable.current = nil
         }
+        localRepositories.userDefaultsRepository.set(TimetableDto.self, key: .currentTimetable, value: nil)
         localRepositories.userDefaultsRepository.set(String.self, key: .accessToken, value: nil)
         localRepositories.userDefaultsRepository.set(String.self, key: .userId, value: nil)
         localRepositories.userDefaultsRepository.set(UserDto.self, key: .userDto, value: nil)

--- a/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
+++ b/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
@@ -12,6 +12,8 @@ protocol GlobalUIServiceProtocol {
     func setColorScheme(_ colorScheme: ColorScheme?)
     func loadColorSchemeDuringBootstrap()
 
+    func setSelectedTab(_ tab: TabType)
+    func setIsErrorAlertPresented(_ value: Bool)
     func setIsMenuOpen(_ value: Bool)
 
     func openEllipsis(for timetable: TimetableMetadata)
@@ -56,6 +58,14 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
         let colorSchemeDescription = localRepositories.userDefaultsRepository.get(String.self, key: .preferredColorScheme)
         let colorScheme = ColorScheme.from(description: colorSchemeDescription)
         appState.system.preferredColorScheme = colorScheme
+    }
+    
+    func setSelectedTab(_ tab: TabType) {
+        appState.system.selectedTab = tab
+    }
+    
+    func setIsErrorAlertPresented(_ value: Bool) {
+        appState.system.isErrorAlertPresented = value
     }
 
     func setIsMenuOpen(_ value: Bool) {

--- a/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
+++ b/SNUTT-2022/SNUTT/Services/GlobalUIService.swift
@@ -59,11 +59,11 @@ struct GlobalUIService: GlobalUIServiceProtocol, UserAuthHandler {
         let colorScheme = ColorScheme.from(description: colorSchemeDescription)
         appState.system.preferredColorScheme = colorScheme
     }
-    
+
     func setSelectedTab(_ tab: TabType) {
         appState.system.selectedTab = tab
     }
-    
+
     func setIsErrorAlertPresented(_ value: Bool) {
         appState.system.isErrorAlertPresented = value
     }

--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -101,6 +101,8 @@ extension LectureDetailScene {
         func fetchReviewId(of lecture: Lecture) async -> String? {
             do {
                 return try await lectureService.fetchReviewId(courseNumber: lecture.courseNumber, instructor: lecture.instructor)
+            } catch let error as STError where error.code == .EMAIL_NOT_VERIFIED {
+                // noop
             } catch {
                 services.globalUIService.presentErrorAlert(error: error)
             }

--- a/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchSceneViewModel.swift
@@ -19,10 +19,10 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
     @Published var selectedTagList: [SearchTag] = []
     @Published var isLoading: Bool = false
     @Published var isLectureOverlapped: Bool = false
-    
+
     @Published var emailVerifyError: STError? = nil
     @Published var presentEmailVerifyAlert = false
-    
+
     var errorTitle: String = ""
     var errorMessage: String = ""
 
@@ -40,7 +40,7 @@ class SearchSceneViewModel: BaseViewModel, ObservableObject {
         get { _selectedLecture }
         set { services.searchService.setSelectedLecture(newValue) }
     }
-    
+
     var selectedTab: TabType {
         get { _selectedTab }
         set { services.globalUIService.setSelectedTab(newValue) }

--- a/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/TimetableViewModel.swift
@@ -108,8 +108,4 @@ class TimetableViewModel: BaseViewModel, ObservableObject {
     private var timetableState: TimetableState {
         appState.timetable
     }
-
-    func preloadWebViews() {
-        services.globalUIService.preloadWebViews()
-    }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchLectureCell.swift
@@ -95,7 +95,7 @@ struct SearchLectureCell: View {
                     /// This `sheet` modifier should be called on `HStack` to prevent animation glitch when `dismiss`ed.
                     .sheet(isPresented: $showReviewWebView) {
                         if let container = container {
-                            ReviewScene(viewModel: .init(container: container), detailId: $reviewId)
+                            ReviewScene(viewModel: .init(container: container), isMainWebView: false, detailId: $reviewId)
                                 .id(reviewId)
                         }
                     }

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -99,14 +99,13 @@ extension SNUTTView {
         @Published var accessToken: String? = nil
         @Published var preferredColorScheme: ColorScheme? = nil
         @Published private var error: STError? = nil
-        
+
         @Published private var _isErrorAlertPresented = false
         var isErrorAlertPresented: Bool {
             get { _isErrorAlertPresented }
             set { services.globalUIService.setIsErrorAlertPresented(newValue) }
         }
-        
-        
+
         @Published private var _selectedTab: TabType = .review
         var selectedTab: TabType {
             get { _selectedTab }

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -53,6 +53,11 @@ struct SNUTTView: View {
                         SettingScene(viewModel: .init(container: viewModel.container))
                     }
                 }
+                .onAppear {
+                    viewModel.selectedTab = .timetable
+                    viewModel.preloadWebViews()
+                }
+                
                 if viewModel.selectedTab == .timetable {
                     MenuSheetScene(viewModel: .init(container: viewModel.container))
                     LectureTimeSheetScene(viewModel: .init(container: viewModel.container))
@@ -136,6 +141,10 @@ extension SNUTTView {
 
         func reloadReviewWebView() {
             services.globalUIService.sendMainWebViewReloadSignal()
+        }
+        
+        func preloadWebViews() {
+            services.globalUIService.preloadWebViews()
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/SNUTTView.swift
+++ b/SNUTT-2022/SNUTT/Views/SNUTTView.swift
@@ -57,7 +57,7 @@ struct SNUTTView: View {
                     viewModel.selectedTab = .timetable
                     viewModel.preloadWebViews()
                 }
-                
+
                 if viewModel.selectedTab == .timetable {
                     MenuSheetScene(viewModel: .init(container: viewModel.container))
                     LectureTimeSheetScene(viewModel: .init(container: viewModel.container))
@@ -142,7 +142,7 @@ extension SNUTTView {
         func reloadReviewWebView() {
             services.globalUIService.sendMainWebViewReloadSignal()
         }
-        
+
         func preloadWebViews() {
             services.globalUIService.preloadWebViews()
         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -207,7 +207,7 @@ struct LectureDetailScene: View {
                             viewModel.reloadDetailWebView(detailId: reviewId)
                         }
                         .sheet(isPresented: $showReviewWebView) {
-                            ReviewScene(viewModel: .init(container: viewModel.container), detailId: $reviewId)
+                            ReviewScene(viewModel: .init(container: viewModel.container), isMainWebView: false, detailId: $reviewId)
                                 .id(colorScheme)
                                 .id(reviewId)
                         }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -11,17 +11,19 @@ import SwiftUI
 struct ReviewScene: View {
     @ObservedObject var viewModel: ViewModel
     @Binding var detailId: String?
+    private var isMainWebView: Bool
 
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
 
-    init(viewModel: ViewModel, detailId: Binding<String?> = .constant(nil)) {
+    init(viewModel: ViewModel, isMainWebView: Bool, detailId: Binding<String?> = .constant(nil)) {
         self.viewModel = viewModel
         _detailId = detailId
+        self.isMainWebView = isMainWebView
     }
 
     private var eventSignal: PassthroughSubject<WebViewEventType, Never>? {
-        viewModel.getPreloadedWebView(detailId: detailId).eventSignal
+        viewModel.getPreloadedWebView(isMain: isMainWebView).eventSignal
     }
 
     private var reviewUrl: URL {
@@ -34,7 +36,7 @@ struct ReviewScene: View {
 
     var body: some View {
         ZStack {
-            ReviewWebView(preloadedWebView: viewModel.getPreloadedWebView(detailId: detailId))
+            ReviewWebView(preloadedWebView: viewModel.getPreloadedWebView(isMain: isMainWebView))
                 .navigationBarHidden(true)
                 .edgesIgnoringSafeArea(.bottom)
                 .background(STColor.systemBackground)
@@ -92,8 +94,8 @@ extension ReviewScene {
             }.store(in: &bag)
         }
 
-        func getPreloadedWebView(detailId: String?) -> WebViewPreloadManager {
-            if detailId == nil {
+        func getPreloadedWebView(isMain: Bool) -> WebViewPreloadManager {
+            if isMain {
                 return appState.review.preloadedMain
             } else {
                 return appState.review.preloadedDetail

--- a/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
@@ -82,6 +82,17 @@ struct SearchLectureScene: View {
             .task {
                 await viewModel.fetchTags()
             }
+            .alert(viewModel.emailVerifyError?.title ?? "", isPresented: $viewModel.presentEmailVerifyAlert, actions: {
+                Button("확인") {
+                    viewModel.emailVerifyError = nil
+                    viewModel.selectedTab = .review
+                }
+                Button("취소", role: .cancel) {
+                    viewModel.emailVerifyError = nil
+                }
+            }, message: {
+                Text(viewModel.emailVerifyError?.content ?? "")
+            })
             .navigationBarHidden(true)
             .animation(.customSpring, value: viewModel.searchResult?.count)
             .animation(.customSpring, value: viewModel.isLoading)

--- a/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
@@ -70,8 +70,6 @@ struct TimetableScene: View {
                     ActivityViewController(activityItems: [screenshot, linkMetadata])
                 }
                 .onLoad {
-                    viewModel.preloadWebViews()
-
                     await withTaskGroup(of: Void.self, body: { group in
                         group.addTask {
                             await viewModel.fetchTimetableList()


### PR DESCRIPTION
- 검색 리스트에서 강의평으로 바로 이동할 때, 이메일 미인증 사용자의 경우에는 강의평 탭에서 이메일 인증 진행하도록 플로우 변경
- 로그아웃할 때 초기화되어야 할 정보가 초기화되지 않는 문제 수정