### PR TITLE
`개발자 괴롭히기` 이메일 자동 입력

### DIFF
--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -19,6 +19,10 @@ class SettingViewModel: BaseViewModel, ObservableObject {
         appState.notification.$notifications.assign(to: &$notifications)
         appState.notification.$unreadCount.assign(to: &$unreadCount)
     }
+    
+    var userEmail: String? {
+        appState.user.current?.email
+    }
 
     func fetchInitialNotifications(updateLastRead: Bool) async {
         do {

--- a/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SettingViewModel.swift
@@ -19,7 +19,7 @@ class SettingViewModel: BaseViewModel, ObservableObject {
         appState.notification.$notifications.assign(to: &$notifications)
         appState.notification.$unreadCount.assign(to: &$unreadCount)
     }
-    
+
     var userEmail: String? {
         appState.user.current?.email
     }

--- a/SNUTT-2022/SNUTT/Views/Components/UserSupportView.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/UserSupportView.swift
@@ -14,7 +14,7 @@ struct UserSupportView: View {
     @State private var content: String = ""
     @State private var hasEmail: Bool = false
     @State private var alertSendFeedback: Bool = false
-    @FocusState private var _isFocused: Bool
+    @FocusState private var isFocused: Bool
     @Environment(\.presentationMode) private var mode
 
     init(email: String?, sendFeedback: @escaping (String, String) async -> Bool) {
@@ -33,12 +33,13 @@ struct UserSupportView: View {
         Form {
             Section(header: Text("이메일 주소")) {
                 TextField("이메일", text: $email)
+                    .foregroundColor(hasEmail ? .secondary : .primary)
                     .disabled(hasEmail)
             }
             Section(header: Text("문의 내용"), footer: Text("불편한 점이나 버그를 제보해주세요.")) {
                 TextEditor(text: $content)
                     .frame(minHeight: 300)
-                    .focused($_isFocused)
+                    .focused($isFocused)
             }
         }
         .navigationBarTitleDisplayMode(.inline)
@@ -57,7 +58,7 @@ struct UserSupportView: View {
                 Spacer()
 
                 Button("완료") {
-                    _isFocused = false
+                    isFocused = false
                 }
             }
         }

--- a/SNUTT-2022/SNUTT/Views/Components/UserSupportView.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/UserSupportView.swift
@@ -12,8 +12,18 @@ struct UserSupportView: View {
 
     @State private var email: String = ""
     @State private var content: String = ""
+    @State private var hasEmail: Bool = false
     @State private var alertSendFeedback: Bool = false
+    @FocusState private var _isFocused: Bool
     @Environment(\.presentationMode) private var mode
+    
+    init(email: String?, sendFeedback: @escaping (String, String) async -> Bool) {
+        self.sendFeedback = sendFeedback
+        self._email = .init(initialValue: email ?? "")
+        if let email = email {
+            self._hasEmail = .init(initialValue: !email.isEmpty)
+        }
+    }
 
     var isButtonDisabled: Bool {
         email.isEmpty || content.isEmpty
@@ -23,10 +33,12 @@ struct UserSupportView: View {
         Form {
             Section(header: Text("이메일 주소")) {
                 TextField("이메일", text: $email)
+                    .disabled(hasEmail)
             }
             Section(header: Text("문의 내용"), footer: Text("불편한 점이나 버그를 제보해주세요.")) {
                 TextEditor(text: $content)
                     .frame(minHeight: 300)
+                    .focused($_isFocused)
             }
         }
         .navigationBarTitleDisplayMode(.inline)
@@ -39,6 +51,14 @@ struct UserSupportView: View {
                     Text("전송")
                 }
                 .disabled(isButtonDisabled)
+            }
+            
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                
+                Button("완료") {
+                    _isFocused = false
+                }
             }
         }
         .alert("개발자 괴롭히기", isPresented: $alertSendFeedback) {
@@ -59,8 +79,10 @@ struct UserSupportView: View {
 
 struct UserSupportScene_Previews: PreviewProvider {
     static var previews: some View {
-        UserSupportView { _, _ in
-            true
+        NavigationView {
+            UserSupportView(email: "snutt@wafflestudio.com") { _, _ in
+                true
+            }
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/UserSupportView.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/UserSupportView.swift
@@ -16,12 +16,12 @@ struct UserSupportView: View {
     @State private var alertSendFeedback: Bool = false
     @FocusState private var _isFocused: Bool
     @Environment(\.presentationMode) private var mode
-    
+
     init(email: String?, sendFeedback: @escaping (String, String) async -> Bool) {
         self.sendFeedback = sendFeedback
-        self._email = .init(initialValue: email ?? "")
+        _email = .init(initialValue: email ?? "")
         if let email = email {
-            self._hasEmail = .init(initialValue: !email.isEmpty)
+            _hasEmail = .init(initialValue: !email.isEmpty)
         }
     }
 
@@ -52,10 +52,10 @@ struct UserSupportView: View {
                 }
                 .disabled(isButtonDisabled)
             }
-            
+
             ToolbarItemGroup(placement: .keyboard) {
                 Spacer()
-                
+
                 Button("완료") {
                     _isFocused = false
                 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/SettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/SettingScene.swift
@@ -37,7 +37,7 @@ struct SettingScene: View {
                     DeveloperInfoView()
                 }
                 SettingsLinkItem(title: "개발자 괴롭히기") {
-                    UserSupportView(sendFeedback: viewModel.sendFeedback(email:message:))
+                    UserSupportView(email: viewModel.userEmail, sendFeedback: viewModel.sendFeedback(email:message:))
                 }
             }
 


### PR DESCRIPTION
- `개발자 괴롭히기`에서 유저 이메일이 있는 경우에는 자동으로 필드를 채워주고+수정 불가능, 유저 이메일이 없는 경우에만 직접 입력하도록 수정
- 문의 내용이 긴 경우 keyboard를 dismiss할 수 없었던 문제 수정