### PR TITLE
웹뷰 쿠키 관련 문제 수정

### DIFF
--- a/SNUTT-2022/SNUTT/Extensions/ColorScheme.swift
+++ b/SNUTT-2022/SNUTT/Extensions/ColorScheme.swift
@@ -31,3 +31,18 @@ extension ColorScheme {
         return nil
     }
 }
+
+extension UIUserInterfaceStyle {
+    func toColorScheme() -> ColorScheme {
+        switch self {
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        case .unspecified:
+            return .light
+        @unknown default:
+            return .light
+        }
+    }
+}

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
@@ -24,7 +24,7 @@ extension WebView {
 
 extension WKWebView {
     convenience init(cookies: [HTTPCookie]) {
-        let dataStore = WKWebsiteDataStore.nonPersistent()
+        let dataStore = WKWebsiteDataStore.default()
         let configuration = WKWebViewConfiguration()
         for cookie in cookies {
             dataStore.httpCookieStore.setCookie(cookie)
@@ -33,8 +33,12 @@ extension WKWebView {
         self.init(frame: .zero, configuration: configuration)
     }
 
+    var cookieStore: WKHTTPCookieStore {
+        configuration.websiteDataStore.httpCookieStore
+    }
+
     func setCookie(name: String, value: String) {
         guard let cookie = NetworkConfiguration.getCookie(name: name, value: value) else { return }
-        configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+        cookieStore.setCookie(cookie)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -20,6 +20,10 @@ struct ReviewScene: View {
         self.viewModel = viewModel
         _detailId = detailId
         self.isMainWebView = isMainWebView
+
+        /// It's too early to access `colorScheme` environment variable during the init phase.
+        /// Use the system color scheme instead.
+        eventSignal?.send(.colorSchemeChange(to: UITraitCollection.current.userInterfaceStyle.toColorScheme()))
     }
 
     private var eventSignal: PassthroughSubject<WebViewEventType, Never>? {


### PR DESCRIPTION
- `WKWebsiteDataStore`가 `nonPersistent`로 설정되어 있는 것이 최근 에러의 원인일 가능성이 커보입니다. 
    - 아마 SNUTT 2.0의 코드를 복붙해오다가 포함된 것 같은데, 혹시 이게 `nonPersistent`로 설정되어야 할 이유가 있었나요? @peng-u-0807 
    - #215 여기서는 매번 쿠키를 리셋해주도록 했는데, 일단 이 PR로 해결이 안된다면 저 방식으로 다시 시도해야 할 것 같아요.
- Theme 쿠키를 조금 더 일찍 주입하도록 변경했습니다.

