### PR TITLE
웹뷰 쿠키 관련 개선

### DIFF
--- a/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/ReviewState.swift
@@ -39,7 +39,7 @@ class WebViewPreloadManager {
         webView?.allowsBackForwardNavigationGestures = url == WebViewType.review.url
         self.url = url
     }
-    
+
     func setColorScheme(_ colorScheme: ColorScheme) {
         webView?.setCookie(name: "theme", value: colorScheme.description)
         webView?.evaluateJavaScript("changeTheme('\(colorScheme.description)')")
@@ -54,9 +54,9 @@ class WebViewPreloadManager {
                 default:
                     return
                 }
-        }
-        .store(in: &bag)
-            
+            }
+            .store(in: &bag)
+
         /// The `colorScheme` value can be quite unstable, especially during the SwiftUI lifecycle.
         /// To address this, we debounce it for 0.1 seconds.
         eventSignal?

--- a/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
@@ -12,6 +12,9 @@ import UIKit
 class SystemState: ObservableObject {
     @Published var isErrorAlertPresented = false
     @Published var error: STError? = nil
+    
+    /// The property stores the color scheme that the user has set as their preference.
+    /// If `nil`, the system appearance will be used.
     @Published var preferredColorScheme: ColorScheme? = nil
 
     @Published var selectedTab: TabType = .timetable

--- a/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
+++ b/SNUTT-2022/SNUTT/AppState/States/SystemState.swift
@@ -12,7 +12,7 @@ import UIKit
 class SystemState: ObservableObject {
     @Published var isErrorAlertPresented = false
     @Published var error: STError? = nil
-    
+
     /// The property stores the color scheme that the user has set as their preference.
     /// If `nil`, the system appearance will be used.
     @Published var preferredColorScheme: ColorScheme? = nil

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
@@ -41,7 +41,7 @@ extension WKWebView {
         guard let cookie = NetworkConfiguration.getCookie(name: name, value: value) else { return }
         cookieStore.setCookie(cookie)
     }
-    
+
     func setCookies(cookies: [HTTPCookie]) {
         cookies.forEach { cookie in
             cookieStore.setCookie(cookie)

--- a/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/WebViews/WebViewProtocol.swift
@@ -41,4 +41,10 @@ extension WKWebView {
         guard let cookie = NetworkConfiguration.getCookie(name: name, value: value) else { return }
         cookieStore.setCookie(cookie)
     }
+    
+    func setCookies(cookies: [HTTPCookie]) {
+        cookies.forEach { cookie in
+            cookieStore.setCookie(cookie)
+        }
+    }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -123,11 +123,14 @@ extension ReviewScene {
         }
 
         func getPreloadedWebView(isMain: Bool) -> WebViewPreloadManager {
-            if isMain {
-                return appState.review.preloadedMain
-            } else {
-                return appState.review.preloadedDetail
+            let webviewManager = isMain ? appState.review.preloadedMain : appState.review.preloadedDetail
+            
+            // make sure the webview has all required cookies
+            if let accessToken = appState.user.accessToken {
+                webviewManager.webView?.setCookies(cookies: NetworkConfiguration.getCookiesFrom(accessToken: accessToken))
             }
+            
+            return webviewManager
         }
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -13,7 +13,6 @@ struct ReviewScene: View {
     @Binding var detailId: String?
     
     private var isMainWebView: Bool
-    @State private var isAppForeground = true
 
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
@@ -63,18 +62,8 @@ struct ReviewScene: View {
             eventSignal?.send(.colorSchemeChange(to: newValue))
         }
         /// Respond to changes of system color scheme.
-        /// The `isAppForeground` variable is used to ignore fluctuations in the `colorScheme`
-        /// when the app is transitioning from the background to the foreground.
         .onChange(of: colorScheme) { newValue in
-            if isAppForeground {
-                eventSignal?.send(.colorSchemeChange(to: newValue))
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-            isAppForeground = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
-            isAppForeground = false
+            eventSignal?.send(.colorSchemeChange(to: newValue))
         }
         .onReceive(eventSignal ?? .init()) { signal in
             switch signal {

--- a/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/ReviewScene.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct ReviewScene: View {
     @ObservedObject var viewModel: ViewModel
     @Binding var detailId: String?
-    
+
     private var isMainWebView: Bool
 
     @Environment(\.colorScheme) var colorScheme
@@ -101,7 +101,7 @@ extension ReviewScene {
                     self.accessToken = ""
                 }
             }.store(in: &bag)
-            
+
             appState.system.$preferredColorScheme.sink { newValue in
                 if let newValue {
                     self.preferredColorScheme = newValue
@@ -113,12 +113,12 @@ extension ReviewScene {
 
         func getPreloadedWebView(isMain: Bool) -> WebViewPreloadManager {
             let webviewManager = isMain ? appState.review.preloadedMain : appState.review.preloadedDetail
-            
+
             // make sure the webview has all required cookies
             if let accessToken = appState.user.accessToken {
                 webviewManager.webView?.setCookies(cookies: NetworkConfiguration.getCookiesFrom(accessToken: accessToken))
             }
-            
+
             return webviewManager
         }
     }


### PR DESCRIPTION
# 강의평 고양이 재현 경로

## 3.1.0 이하
(신형 아이폰 / 시뮬레이터에서는 재현 잘 안됨)
1. 강의평 탭 열어놓은 상태에서
2. 카메라 앱을 열고 비디오를 20초간 찍는다
3. 스누티티 앱으로 돌아간다
4. (메모리 부족으로) 웹뷰가 리프레시되면서 쿠키 날라가고 고양이 등장

3.1.1 이상부터는 cookie store가 `nonPersistent`로 설정되어 있는 문제를 수정(#216)했기 때문에 위 이슈는 재현되지 않습니다.

다만 1) SwiftUI 뷰가 리프레시되는 시점, 웹뷰가 리프레시되는 시점, `theme` 쿠키가 주입되는 시점이 모두 다르고, 2) 뷰 리프레시 도중에 시스템 `colorScheme`을 읽을 때 부정확한 값이 읽히는 버그 때문에 웹뷰 테마가 정확하게 동기화되지 않는 문제가 있었습니다.

이 문제는 colorScheme의 변경을 처리하는 eventSignal을 debouncing 처리해주어서 해결했습니다.

그리고 아직 고양이 웹뷰가 메모리에 남아있는 상태에서 preloading을 계속 해주게 되면 트러플로 스팸이 갈 것 같아서 웹뷰 접근할 때마다 쿠키를 리셋해주는 코드도 추가했습니다.


