### PR TITLE
Fix wrong start-end time, weekday for empty timetable

### DIFF
--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
@@ -57,11 +57,11 @@ struct TimetablePainter {
         if !config.autoFit {
             return config.minHour
         }
-        
+
         if current?.lectures.isEmpty ?? true {
             return 9
         }
-        
+
         guard let startTime = current?.earliestStartTime else {
             return config.minHour
         }
@@ -74,7 +74,7 @@ struct TimetablePainter {
         if !config.autoFit {
             return config.maxHour
         }
-        
+
         if current?.lectures.isEmpty ?? true {
             return 17
         }
@@ -99,7 +99,7 @@ struct TimetablePainter {
         if !config.autoFit {
             return config.visibleWeeksSorted
         }
-        
+
         if current?.lectures.isEmpty ?? true {
             return [.mon, .tue, .wed, .thu, .fri]
         }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
@@ -55,32 +55,34 @@ struct TimetablePainter {
     /// `autoFit`을 고려한 시간표의 시작 시각. 빈 시간표일 때에는 기본 9시이다.
     static func getStartingHour(current: Timetable?, config: TimetableConfiguration) -> Int {
         if let _ = current?.lectures.isEmpty,
-           current?.earliestStartTime == nil {
+           current?.earliestStartTime == nil
+        {
             return 9
         }
-        
+
         if !config.autoFit {
             return config.minHour
         }
-        
+
         guard let startTime = current?.earliestStartTime else {
             return config.minHour
         }
-        
+
         return Int(min(startTime, 9))
     }
 
     /// `autoFit`을 고려한 시간표의 종료 시각. 빈 시간표일 때에는 기본 17시이다.
     static func getEndingHour(current: Timetable?, config: TimetableConfiguration) -> Int {
         if let _ = current?.lectures.isEmpty,
-           current?.lastEndTime == nil {
+           current?.lastEndTime == nil
+        {
             return 17
         }
-        
+
         if !config.autoFit {
             return config.maxHour
         }
-        
+
         guard let endTime = current?.lastEndTime else {
             return config.maxHour
         }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
@@ -52,22 +52,35 @@ struct TimetablePainter {
 
     // MARK: Auto Fit
 
-    /// `autoFit`을 고려한 시간표의 시작 시각. 빈 시간표일 때에는 설정 값을 따른다.
+    /// `autoFit`을 고려한 시간표의 시작 시각. 빈 시간표일 때에는 기본 9시이다.
     static func getStartingHour(current: Timetable?, config: TimetableConfiguration) -> Int {
+        if let _ = current?.lectures.isEmpty,
+           current?.earliestStartTime == nil {
+            return 9
+        }
+        
         if !config.autoFit {
             return config.minHour
         }
+        
         guard let startTime = current?.earliestStartTime else {
             return config.minHour
         }
-        return Int(min(startTime, 10))
+        
+        return Int(min(startTime, 9))
     }
 
-    /// `autoFit`을 고려한 시간표의 종료 시각. 빈 시간표일 때에는 설정 값을 따른다.
+    /// `autoFit`을 고려한 시간표의 종료 시각. 빈 시간표일 때에는 기본 17시이다.
     static func getEndingHour(current: Timetable?, config: TimetableConfiguration) -> Int {
+        if let _ = current?.lectures.isEmpty,
+           current?.lastEndTime == nil {
+            return 17
+        }
+        
         if !config.autoFit {
             return config.maxHour
         }
+        
         guard let endTime = current?.lastEndTime else {
             return config.maxHour
         }

--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableUtils.swift
@@ -52,18 +52,16 @@ struct TimetablePainter {
 
     // MARK: Auto Fit
 
-    /// `autoFit`을 고려한 시간표의 시작 시각. 빈 시간표일 때에는 기본 9시이다.
+    /// `autoFit`을 고려한 시간표의 시작 시각. 빈 시간표인 경우 기본 9시이다.
     static func getStartingHour(current: Timetable?, config: TimetableConfiguration) -> Int {
-        if let _ = current?.lectures.isEmpty,
-           current?.earliestStartTime == nil
-        {
-            return 9
-        }
-
         if !config.autoFit {
             return config.minHour
         }
-
+        
+        if current?.lectures.isEmpty ?? true {
+            return 9
+        }
+        
         guard let startTime = current?.earliestStartTime else {
             return config.minHour
         }
@@ -71,16 +69,14 @@ struct TimetablePainter {
         return Int(min(startTime, 9))
     }
 
-    /// `autoFit`을 고려한 시간표의 종료 시각. 빈 시간표일 때에는 기본 17시이다.
+    /// `autoFit`을 고려한 시간표의 종료 시각. 빈 시간표인 경우 기본 17시이다.
     static func getEndingHour(current: Timetable?, config: TimetableConfiguration) -> Int {
-        if let _ = current?.lectures.isEmpty,
-           current?.lastEndTime == nil
-        {
-            return 17
-        }
-
         if !config.autoFit {
             return config.maxHour
+        }
+        
+        if current?.lectures.isEmpty ?? true {
+            return 17
         }
 
         guard let endTime = current?.lastEndTime else {
@@ -98,10 +94,14 @@ struct TimetablePainter {
         return end - start + 1
     }
 
-    /// `autoFit`을 고려한 시간표 요일들
+    /// `autoFit`을 고려한 시간표 요일들. 빈 시간표인 경우 기본 월~금이다.
     static func getVisibleWeeks(current: Timetable?, config: TimetableConfiguration) -> [Weekday] {
         if !config.autoFit {
             return config.visibleWeeksSorted
+        }
+        
+        if current?.lectures.isEmpty ?? true {
+            return [.mon, .tue, .wed, .thu, .fri]
         }
 
         guard let lastWeekDay = current?.lastWeekDay else {


### PR DESCRIPTION
Resolves #224 

- 시간표가 비어있는 경우에는 자동 맞춤 모드와 관계 없이 기본적으로 9-17시를 보여주고, 월-금을 보여주도록 합니다