### PR TITLE
Notification cell height 계산 잘못되는 버그 수정

### DIFF
--- a/SNUTT-2022/SNUTT/Debug/NetworkInspector/NetworkLogListScene.swift
+++ b/SNUTT-2022/SNUTT/Debug/NetworkInspector/NetworkLogListScene.swift
@@ -5,11 +5,11 @@
 //  Created by 박신홍 on 2023/05/09.
 //
 
+#if DEBUG
 import Alamofire
 import Foundation
 import SwiftUI
 
-#if DEBUG
     struct NetworkLogListScene: View {
         @ObservedObject var viewModel: ViewModel
 
@@ -21,6 +21,15 @@ import SwiftUI
                     }
                 }
             }
+            .toolbar {
+                Button {
+                    viewModel.reset()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .imageScale(.medium)
+                }
+
+            }
         }
     }
 
@@ -31,6 +40,10 @@ import SwiftUI
             override init(container: DIContainer) {
                 super.init(container: container)
                 appState.debug.currentLogs.assign(to: &$logs)
+            }
+
+            func reset() {
+                appState.debug.networkLogStore.reset()
             }
         }
     }

--- a/SNUTT-2022/SNUTT/Debug/NetworkInspector/NetworkLogListScene.swift
+++ b/SNUTT-2022/SNUTT/Debug/NetworkInspector/NetworkLogListScene.swift
@@ -6,9 +6,9 @@
 //
 
 #if DEBUG
-import Alamofire
-import Foundation
-import SwiftUI
+    import Alamofire
+    import Foundation
+    import SwiftUI
 
     struct NetworkLogListScene: View {
         @ObservedObject var viewModel: ViewModel
@@ -28,7 +28,6 @@ import SwiftUI
                     Image(systemName: "arrow.clockwise")
                         .imageScale(.medium)
                 }
-
             }
         }
     }

--- a/SNUTT-2022/SNUTT/Debug/NetworkInspector/NetworkLogStore.swift
+++ b/SNUTT-2022/SNUTT/Debug/NetworkInspector/NetworkLogStore.swift
@@ -36,4 +36,8 @@ class NetworkLogStore {
             logs.removeFirst(logs.count - maxLogEntries)
         }
     }
+
+    func reset() {
+        logs.removeAll()
+    }
 }

--- a/SNUTT-2022/SNUTT/Views/Components/NotificationList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/NotificationList.swift
@@ -34,21 +34,19 @@ struct NotificationList: View {
 }
 
 #if DEBUG
-struct NotificationList_Previews: PreviewProvider {
-    static var notifications: [STNotification] {
-        return [
-            .init(message: "공지", created_at: "2022-04-30T08:11:04.200Z", type: .normal, user_id: ""),
-            .init(message: "공지", created_at: "2022-04-30T08:11:04.201Z", type: .normal, user_id: ""),
-            .init(message: "공지", created_at: "2022-04-30T08:11:04.202Z", type: .normal, user_id: "")
-        ]
-    }
-    static var previews: some View {
-        NotificationList(notifications: notifications) { _ in
-
-        } fetchMore: {
-
+    struct NotificationList_Previews: PreviewProvider {
+        static var notifications: [STNotification] {
+            return [
+                .init(message: "공지", created_at: "2022-04-30T08:11:04.200Z", type: .normal, user_id: ""),
+                .init(message: "공지", created_at: "2022-04-30T08:11:04.201Z", type: .normal, user_id: ""),
+                .init(message: "공지", created_at: "2022-04-30T08:11:04.202Z", type: .normal, user_id: ""),
+            ]
         }
 
+        static var previews: some View {
+            NotificationList(notifications: notifications) { _ in
+
+            } fetchMore: {}
+        }
     }
-}
 #endif

--- a/SNUTT-2022/SNUTT/Views/Components/NotificationList.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/NotificationList.swift
@@ -12,19 +12,19 @@ struct NotificationList: View {
     let initialFetch: (Bool) async -> Void
     let fetchMore: () async -> Void
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(notifications, id: \.hashValue) { notification in
-                    NotificationListCell(notification: notification)
-                        .task {
-                            if notification.hashValue == notifications.last?.hashValue {
-                                await fetchMore()
-                            }
+        List {
+            ForEach(notifications, id: \.hashValue) { notification in
+                NotificationListCell(notification: notification)
+                    .task {
+                        if notification.hashValue == notifications.last?.hashValue {
+                            await fetchMore()
                         }
-                }
+                    }
+                    .listRowBackground(STColor.systemBackground)
+                    .listRowSeparator(.hidden)
             }
-            .animation(.customSpring, value: notifications)
         }
+        .listStyle(.plain)
         .navigationBarTitleDisplayMode(.inline)
         .background(STColor.systemBackground)
         .task {
@@ -32,3 +32,23 @@ struct NotificationList: View {
         }
     }
 }
+
+#if DEBUG
+struct NotificationList_Previews: PreviewProvider {
+    static var notifications: [STNotification] {
+        return [
+            .init(message: "공지", created_at: "2022-04-30T08:11:04.200Z", type: .normal, user_id: ""),
+            .init(message: "공지", created_at: "2022-04-30T08:11:04.201Z", type: .normal, user_id: ""),
+            .init(message: "공지", created_at: "2022-04-30T08:11:04.202Z", type: .normal, user_id: "")
+        ]
+    }
+    static var previews: some View {
+        NotificationList(notifications: notifications) { _ in
+
+        } fetchMore: {
+
+        }
+
+    }
+}
+#endif

--- a/SNUTT-2022/SNUTT/Views/Components/NotificationListCell.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/NotificationListCell.swift
@@ -31,7 +31,7 @@ struct NotificationListCell: View {
                     .font(STFont.detailLabel)
             }
         }
-        .padding()
+        .padding(.vertical, 5)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }


### PR DESCRIPTION
SwiftUI 버그로 추정
(+ 잠수함패치로 네트워크 로그에 초기화 버튼 추가)

| AS-IS | TO-BE |
|:-----:|:-----:|
| ![AS-IS Image](https://github.com/wafflestudio/snutt-ios/assets/33917774/78fe03f0-63a4-429d-847b-c4c8316be4d5) | ![TO-BE Image](https://github.com/wafflestudio/snutt-ios/assets/33917774/639c6ab7-d665-4ce8-af8c-bfb77a48daca) |
