### PR TITLE
이메일 중복 에러코드 추가

### DIFF
--- a/SNUTT-2022/SNUTT/Models/ErrorCode.swift
+++ b/SNUTT-2022/SNUTT/Models/ErrorCode.swift
@@ -98,6 +98,7 @@ enum ErrorCode: Int {
     /* 409 - Conflicts (Email Verification related) */
     case ALREADY_VERIFIED_ACCOUNT = 0x9000
     case ALREADY_VERIFIED_EMAIL = 0x9001
+    case DUPLICATE_EMAIL = 40901
 
     /* 429 - Too many requests */
     case EXCESSIVE_EMAIL_VERIFICATION_REQUEST = 0xA000
@@ -145,6 +146,7 @@ enum ErrorCode: Int {
              .DUPLICATE_ID,
              .DUPLICATE_TIMETABLE_TITLE,
              .DUPLICATE_LECTURE,
+             .DUPLICATE_EMAIL,
              .ALREADY_LOCAL_ACCOUNT,
              .ALREADY_FB_ACCOUNT,
              .ALREADY_VERIFIED_ACCOUNT,
@@ -296,6 +298,8 @@ enum ErrorCode: Int {
             return "잘못된 인증코드입니다."
         case .ALREADY_VERIFIED_ACCOUNT:
             return "이메일 인증이 완료된 계정입니다."
+        case .DUPLICATE_EMAIL:
+            return "이미 사용 중인 이메일입니다."
         case .ALREADY_VERIFIED_EMAIL:
             return "다른 계정에서 인증된 이메일입니다."
         case .EXCESSIVE_EMAIL_VERIFICATION_REQUEST:


### PR DESCRIPTION
에러코드 없으면 중복이메일로 가입시도시 그냥 서버오류라고 떠요
이것도 개선해야되는데.. 일단 이렇게 고쳤습니다.