### PR TITLE
Add support for `friends` notification deeplink

### DIFF
--- a/SNUTT-2022/SNUTT/AppState/DeepLinkHandler.swift
+++ b/SNUTT-2022/SNUTT/AppState/DeepLinkHandler.swift
@@ -38,7 +38,7 @@ extension DeepLinkHandler {
         appState.system.selectedTab = .settings
         appState.routing.settingScene.pushToVacancy = true
     }
-    
+
     private func handleFriends(parameters _: Parameters?) {
         appState.system.selectedTab = .friends
     }

--- a/SNUTT-2022/SNUTT/AppState/DeepLinkHandler.swift
+++ b/SNUTT-2022/SNUTT/AppState/DeepLinkHandler.swift
@@ -18,10 +18,10 @@ struct DeepLinkHandler {
         switch urlComponents.host {
         case "notifications":
             handleNotification(parameters: urlComponents.queryItems)
-            return
         case "vacancy":
             handleVacancy(parameters: urlComponents.queryItems)
-            return
+        case "friends":
+            handleFriends(parameters: urlComponents.queryItems)
         default:
             return
         }
@@ -37,5 +37,9 @@ extension DeepLinkHandler {
     private func handleVacancy(parameters _: Parameters?) {
         appState.system.selectedTab = .settings
         appState.routing.settingScene.pushToVacancy = true
+    }
+    
+    private func handleFriends(parameters _: Parameters?) {
+        appState.system.selectedTab = .friends
     }
 }


### PR DESCRIPTION
- 친구 관련 푸시 알림을 탭하는 경우에는 친구 탭으로 곧장 이동합니다