### PR TITLE
Fix alert not showing for invalid semester(vacancy)

### DIFF
--- a/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/LectureDetailViewModel.swift
@@ -191,6 +191,10 @@ extension LectureDetailScene {
         func addVacancyLecture(lecture: Lecture) async {
             do {
                 try await services.vacancyService.addLecture(lecture: lecture)
+            } catch let error as STError where error.code == .INVALID_SEMESTER_FOR_VACANCY_NOTIFICATION {
+                isErrorAlertPresented = true
+                errorTitle = error.title
+                errorMessage = error.content
             } catch {
                 services.globalUIService.presentErrorAlert(error: error)
             }

--- a/SNUTT-2022/SNUTT/Views/Scenes/Settings/ColorSchemeSettingScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/Settings/ColorSchemeSettingScene.swift
@@ -29,6 +29,6 @@ struct ColorSchemeSettingScene: View {
             }
         }
         .listStyle(.insetGrouped)
-        .navigationTitle("색상 모드")
+        .navigationTitle("화면 모드")
     }
 }


### PR DESCRIPTION
### 수정사항
- `강의 검색 > 강의 하나 선택 > 자세히 > 빈자리 알림 버튼 터치` 시 빈자리 알림을 신청할 수 없는 학기에 대한 alert 뜨지 않는 문제 수정
- 추가로 환경설정 탭에서 `색상 모드` -> `화면 모드` 문구 변경 (피그마 따라서)