### PR TITLE
Fix small place label

### DIFF
--- a/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlock.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Timetable/TimetableBlock.swift
@@ -28,8 +28,7 @@ struct TimetableBlock: View {
                         Text(timePlace.place)
                             .font(STFont.detailsSemibold)
                             .padding(.top, 2)
-                            .minimumScaleFactor(0.5)
-                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
                     }
                 }
                 .multilineTextAlignment(.center)


### PR DESCRIPTION
### 수정사항
- "장소" 라벨의 line limit을 없애고 scaling을 조정했습니다

<img src="https://github.com/wafflestudio/snutt-ios/assets/70614553/aa307fc1-1aeb-41f1-b27c-af65fc8065c1" width=40% height=40%>
