### PR TITLE
Fix sheet not dismissing (email verification)

### DIFF
--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -294,6 +294,9 @@ struct LectureDetailScene: View {
                         .alert(viewModel.errorTitle, isPresented: $viewModel.isEmailVerifyAlertPresented, actions: {
                             Button("확인") {
                                 viewModel.selectedTab = .review
+                                if displayMode == .preview {
+                                    dismiss()
+                                }
                             }
                             Button("취소", role: .cancel) {}
                         }, message: {


### PR DESCRIPTION
### 수정사항
- 강의평 확인을 위한 이메일 인증이 완료되지 않았을 때, "이메일 인증으로 바로 가기"에 대해 강의 상세 뷰(sheet)가 dismiss되지 않던 문제 수정