### PR TITLE
Fix widget padding + dismiss keyboard if `SearchTips` area is touched

### DIFF
--- a/SNUTT-2022/SNUTT/Views/Components/Search/SearchTips.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/Search/SearchTips.swift
@@ -51,6 +51,8 @@ struct SearchTips: View {
 
             Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
         .foregroundColor(STColor.whiteTranslucent)
     }
 }

--- a/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
@@ -89,6 +89,9 @@ struct SearchLectureScene: View {
                         .frame(maxHeight: .infinity, alignment: .center)
                 } else if viewModel.searchResult == nil {
                     SearchTips()
+                        .onTapGesture {
+                            isSearchBarFocused = false
+                        }
                 } else if viewModel.searchResult?.count == 0 {
                     EmptySearchResult()
                 } else if let searchResult = viewModel.searchResult {

--- a/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableCompactWidgetView.swift
+++ b/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableCompactWidgetView.swift
@@ -14,18 +14,15 @@ struct TimetableCompactWidgetView: View {
     @Environment(\.widgetFamily) private var family
 
     var body: some View {
-        ZStack {
-            STColor.systemBackground
-            HStack {
-                TimetableCompactLeftView(entry: entry)
+        HStack {
+            TimetableCompactLeftView(entry: entry)
 
-                if family == .systemMedium && !isTimetableEmpty && !isLoginRequired {
-                    TimetableCompactRightView(entry: entry)
-                        .padding(.leading, 5)
-                }
+            if family == .systemMedium && !isTimetableEmpty && !isLoginRequired {
+                TimetableCompactRightView(entry: entry)
+                    .padding(.leading, 5)
             }
-            .padding(.horizontal, 16)
         }
+        .padding(.horizontal, 16)
     }
 }
 

--- a/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableCompactWidgetView.swift
+++ b/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableCompactWidgetView.swift
@@ -23,6 +23,7 @@ struct TimetableCompactWidgetView: View {
             }
         }
         .padding(.horizontal, 16)
+        .background(STColor.systemBackground)
     }
 }
 

--- a/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableFullWidgetView.swift
+++ b/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableFullWidgetView.swift
@@ -11,9 +11,6 @@ import SwiftUI
 struct TimetableFullWidgetView: View {
     var entry: SNUTTWidgetProvider.Entry
     var body: some View {
-        ZStack {
-            STColor.systemBackground
-            TimetableZStack(current: entry.currentTimetable, config: entry.timetableConfig)
-        }
+        TimetableZStack(current: entry.currentTimetable, config: entry.timetableConfig)
     }
 }

--- a/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableWidget.swift
+++ b/SNUTT-2022/SNUTTWidget/TimetableWidget/TimetableWidget.swift
@@ -23,6 +23,7 @@ struct TimetableWidget: Widget {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: SNUTTWidgetProvider()) { entry in
             TimetableWidgetEntryView(entry: entry)
         }
+        .contentMarginsDisabled()
         .configurationDisplayName("WEEKLY_TIMETABLE".localized)
         .description("주간 시간표입니다.")
         .supportedFamilies(supportedFamilies)


### PR DESCRIPTION
### 수정사항
- iOS 17+에서 위젯 배경에 패딩 들어가있던 문제 수정 (슬랙 링크 못찾겠어서 사진으로 대체..)
- 강의 검색 화면에서 바깥쪽 누르면 키보드 내려가도록 수정 ([피드백](https://wafflestudio.slack.com/archives/C8M9NUBBR/p1706507366989269))
 
<img src=https://github.com/wafflestudio/snutt-ios/assets/70614553/a9c24647-35b5-43ad-94fb-9e60ed551819 width="60%" height="60%"/>
