### PR TITLE
Change `Toolbar` to `HStack`

### DIFF
--- a/SNUTT-2022/SNUTT/Assets/STColor.swift
+++ b/SNUTT-2022/SNUTT/Assets/STColor.swift
@@ -43,7 +43,7 @@ struct STColor {
     static let darkerGray: Color = .init(hex: "#505050")
 
     /// Hex #EBEBEB
-    static let divider: Color = .init(hex: "#EBEBEB")
+    static let divider: Color = .init(hex: "#C4C4C4")
 
     /// Hex #505050
     static let darkDivider: Color = .init(hex: "#505050")

--- a/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
@@ -24,36 +24,27 @@ struct TimetableScene: View, Sendable {
     var body: some View {
         GeometryReader { proxy in
             VStack(spacing: 0) {
-                if viewModel.isVacancyBannerVisible {
-                    VacancyBanner {
-                        viewModel.goToVacancyPage()
+                // toolbar
+                HStack(spacing: 12) {
+                    NavBarButton(imageName: "nav.menu") {
+                        viewModel.setIsMenuOpen(true)
                     }
-                    .transition(.move(edge: .trailing))
-                }
-                timetable
-            }
-            .animation(.customSpring, value: viewModel.isVacancyBannerVisible)
-            .toolbar {
-                ToolbarItemGroup(placement: .principal) {
-                    HStack {
-                        NavBarButton(imageName: "nav.menu") {
-                            viewModel.setIsMenuOpen(true)
-                        }
-                        .circleBadge(condition: viewModel.isNewCourseBookAvailable)
-
-                        HStack(spacing: 8) {
-                            Text(viewModel.timetableTitle)
-                                .font(STFont.title.font)
-                                .minimumScaleFactor(0.9)
-                                .lineLimit(1)
-
-                            Text("(\(viewModel.totalCredit)학점)")
-                                .font(STFont.details.font)
-                                .foregroundColor(Color(UIColor.secondaryLabel))
-                        }
-
+                    .circleBadge(condition: viewModel.isNewCourseBookAvailable)
+                
+                    HStack(spacing: 8) {
+                        Text(viewModel.timetableTitle)
+                            .font(STFont.title.font)
+                            .minimumScaleFactor(0.9)
+                            .lineLimit(1)
+                        
+                        Text("(\(viewModel.totalCredit)학점)")
+                            .font(STFont.details.font)
+                            .foregroundColor(Color(UIColor.secondaryLabel))
+                        
                         Spacer()
-
+                    }
+                    
+                    HStack(spacing: 6) {
                         NavBarButton(imageName: "nav.list") {
                             pushToListScene = true
                         }
@@ -69,7 +60,22 @@ struct TimetableScene: View, Sendable {
                         .circleBadge(condition: viewModel.unreadCount > 0)
                     }
                 }
+                .frame(height: toolBarHeight)
+                .padding(.leading, 16)
+                .padding(.trailing, 12)
+                
+                Rectangle().frame(height: 0.5)
+                    .foregroundStyle(STColor.divider)
+                
+                if viewModel.isVacancyBannerVisible {
+                    VacancyBanner {
+                        viewModel.goToVacancyPage()
+                    }
+                    .transition(.move(edge: .trailing))
+                }
+                timetable
             }
+            .animation(.customSpring, value: viewModel.isVacancyBannerVisible)
         }
         let _ = debugChanges()
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/TimetableScene.swift
@@ -30,20 +30,20 @@ struct TimetableScene: View, Sendable {
                         viewModel.setIsMenuOpen(true)
                     }
                     .circleBadge(condition: viewModel.isNewCourseBookAvailable)
-                
+
                     HStack(spacing: 8) {
                         Text(viewModel.timetableTitle)
                             .font(STFont.title.font)
                             .minimumScaleFactor(0.9)
                             .lineLimit(1)
-                        
+
                         Text("(\(viewModel.totalCredit)학점)")
                             .font(STFont.details.font)
                             .foregroundColor(Color(UIColor.secondaryLabel))
-                        
+
                         Spacer()
                     }
-                    
+
                     HStack(spacing: 6) {
                         NavBarButton(imageName: "nav.list") {
                             pushToListScene = true
@@ -63,10 +63,10 @@ struct TimetableScene: View, Sendable {
                 .frame(height: toolBarHeight)
                 .padding(.leading, 16)
                 .padding(.trailing, 12)
-                
+
                 Rectangle().frame(height: 0.5)
                     .foregroundStyle(STColor.divider)
-                
+
                 if viewModel.isVacancyBannerVisible {
                     VacancyBanner {
                         viewModel.goToVacancyPage()


### PR DESCRIPTION
시간표 탭에서 상세 화면 한번 들어갔다 나오면 상단탭이 다 가운데로 쏠리는 버그 수정
(이전에도 종종 나왔던 버그인데 여태까진 랜덤 재현됐다가 비교적 최신 OS에서는 확정적으로 재현됨)
- ToolbarItem으로는 시간표 제목의 overflow 대응+올바른 spacing 모두 잡기 어려워서 이전에 사용했던 HStack으로 돌아갔습니다
- iOS 16.0, 17.0, 18.0 에서 문제 없는 것 확인