### PR TITLE
Fix: do not show `categoryPre2025` before 2025

### DIFF
--- a/SNUTT-2022/SNUTT/Services/SearchService.swift
+++ b/SNUTT-2022/SNUTT/Services/SearchService.swift
@@ -55,9 +55,6 @@ struct SearchService: SearchServiceProtocol {
 
     func fetchTags(quarter: Quarter) async throws {
         // TODO: get from userDefault
-        if let _ = searchState.searchTagList {
-            return
-        }
         let dto = try await searchRepository.fetchTags(quarter: quarter)
         let model = SearchTagList(from: dto)
         appState.search.searchTagList = model

--- a/SNUTT-2022/SNUTT/ViewModels/SearchLectureSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchLectureSceneViewModel.swift
@@ -33,6 +33,10 @@ class SearchLectureSceneViewModel: BaseViewModel, ObservableObject {
         get { _displayMode }
         set { services.searchService.setSearchDisplayMode(newValue) }
     }
+    
+    var currentTimetable: Timetable? {
+        appState.timetable.current
+    }
 
     override init(container: DIContainer) {
         super.init(container: container)
@@ -62,10 +66,7 @@ class SearchLectureSceneViewModel: BaseViewModel, ObservableObject {
     }
 
     func fetchTags() async {
-        if appState.search.searchTagList != nil {
-            return
-        }
-        guard let currentTimetable = appState.timetable.current else { return }
+        guard let currentTimetable = currentTimetable else { return }
         do {
             try await services.searchService.fetchTags(quarter: currentTimetable.quarter)
         } catch {

--- a/SNUTT-2022/SNUTT/ViewModels/SearchLectureSceneViewModel.swift
+++ b/SNUTT-2022/SNUTT/ViewModels/SearchLectureSceneViewModel.swift
@@ -33,7 +33,7 @@ class SearchLectureSceneViewModel: BaseViewModel, ObservableObject {
         get { _displayMode }
         set { services.searchService.setSearchDisplayMode(newValue) }
     }
-    
+
     var currentTimetable: Timetable? {
         appState.timetable.current
     }

--- a/SNUTT-2022/SNUTT/Views/Components/FilterSheetContent.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/FilterSheetContent.swift
@@ -25,18 +25,24 @@ struct FilterSheetContent: View {
             HStack(spacing: 0) {
                 VStack(spacing: 25) {
                     ForEach(SearchTagType.allCases, id: \.self) { tag in
-                        let isSelected = selectedCategory == tag
-                        Button {
-                            selectedCategory = tag
-                        } label: {
-                            Spacer()
-                            Text(tag.typeStr)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .contentShape(Rectangle())
-                                .font(.system(size: 18, weight: .semibold))
-                                .foregroundColor(isSelected ? Color(uiColor: .label) : Color(uiColor: .label.withAlphaComponent(0.5)))
+                        // ~2024년: `구) 교양영역` 제공X
+                        if tag == .categoryPre2025,
+                           let currentYear = viewModel.currentTimetable?.year, currentYear < 2025 {
+                            EmptyView()
+                        } else {
+                            let isSelected = selectedCategory == tag
+                            Button {
+                                selectedCategory = tag
+                            } label: {
+                                Spacer()
+                                Text(tag.typeStr)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .contentShape(Rectangle())
+                                    .font(.system(size: 18, weight: .semibold))
+                                    .foregroundColor(isSelected ? Color(uiColor: .label) : Color(uiColor: .label.withAlphaComponent(0.5)))
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
                 .frame(maxWidth: 110, maxHeight: .infinity, alignment: .topLeading)

--- a/SNUTT-2022/SNUTT/Views/Components/FilterSheetContent.swift
+++ b/SNUTT-2022/SNUTT/Views/Components/FilterSheetContent.swift
@@ -27,7 +27,8 @@ struct FilterSheetContent: View {
                     ForEach(SearchTagType.allCases, id: \.self) { tag in
                         // ~2024년: `구) 교양영역` 제공X
                         if tag == .categoryPre2025,
-                           let currentYear = viewModel.currentTimetable?.year, currentYear < 2025 {
+                           let currentYear = viewModel.currentTimetable?.year, currentYear < 2025
+                        {
                             EmptyView()
                         } else {
                             let isSelected = selectedCategory == tag

--- a/SNUTT-2022/SNUTT/Views/Scenes/FilterSheetScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/FilterSheetScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FilterSheetScene: View {
     @ObservedObject var viewModel: FilterSheetViewModel
-    
+
     var currentYear: Int {
         viewModel.currentTimetable?.year ?? 0
     }

--- a/SNUTT-2022/SNUTT/Views/Scenes/FilterSheetScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/FilterSheetScene.swift
@@ -9,10 +9,14 @@ import SwiftUI
 
 struct FilterSheetScene: View {
     @ObservedObject var viewModel: FilterSheetViewModel
+    
+    var currentYear: Int {
+        viewModel.currentTimetable?.year ?? 0
+    }
 
     var body: some View {
         Sheet(isOpen: $viewModel.isFilterOpen,
-              orientation: .bottom(maxHeight: 500),
+              orientation: .bottom(maxHeight: currentYear < 2025 ? 450 : 500),
               sheetOpacity: 1)
         {
             VStack {

--- a/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/LectureDetailScene.swift
@@ -337,9 +337,12 @@ struct LectureDetailScene: View {
                         DetailLabel(text: "교양영역")
                         EditableTextField(text: $lecture.category)
                     }
-                    HStack {
-                        DetailLabel(text: "구) 교양영역")
-                        EditableTextField(text: $lecture.categoryPre2025)
+                    // 2025년~: `구) 교양영역` 제공
+                    if let currentYear = viewModel.currentTimetable?.year, currentYear >= 2025 {
+                        HStack {
+                            DetailLabel(text: "구) 교양영역")
+                            EditableTextField(text: $lecture.categoryPre2025)
+                        }
                     }
                     HStack {
                         DetailLabel(text: "강좌번호")

--- a/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
+++ b/SNUTT-2022/SNUTT/Views/Scenes/SearchLectureScene.swift
@@ -40,7 +40,7 @@ struct SearchLectureScene: View {
                 .focused($isSearchBarFocused)
                 .frame(height: Design.searchBarHeight)
         }
-        .task {
+        .task(id: viewModel.currentTimetable?.year) {
             await viewModel.fetchTags()
         }
         .navigationBarHidden(true)


### PR DESCRIPTION
### 수정사항
- 교양영역 관련 [기획 수정사항](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1738309826932779) 반영
- ~2024년: `교양영역`
- 2025년~: `교양영역`, `구) 교양영역`