### PR TITLE
Fix `.lectureUpdate` deeplink not working

### DIFF
--- a/SNUTT-2022/SNUTT/Info.plist
+++ b/SNUTT-2022/SNUTT/Info.plist
@@ -35,6 +35,14 @@
 				<string>kakao$(KAKAO_APP_KEY)</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(URL_SCHEME)</string>
+			</array>
+		</dict>
 	</array>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>
 	<false/>


### PR DESCRIPTION
### 수정사항
- 강의 업데이트 알림에 대한 딥링크가 동작하지 않는 문제 수정