### PR TITLE
♻️ XCTest에서 Swift-Testing으로 마이그레이션

### DIFF
--- a/SNUTT/Modules/Feature/APIClient/Tests/APIClientTests.swift
+++ b/SNUTT/Modules/Feature/APIClient/Tests/APIClientTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class APIClientTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("APIClient", "APIClient")
-    }
+@Test func example() {
+    #expect("APIClient" == "APIClient")
 }

--- a/SNUTT/Modules/Feature/Auth/Tests/AuthTests.swift
+++ b/SNUTT/Modules/Feature/Auth/Tests/AuthTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class AuthTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("Auth", "Auth")
-    }
+@Test func example() {
+    #expect("Auth" == "Auth")
 }

--- a/SNUTT/Modules/Feature/Configs/Tests/ConfigsTests.swift
+++ b/SNUTT/Modules/Feature/Configs/Tests/ConfigsTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class ConfigsTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("Configs", "Configs")
-    }
+@Test func example() {
+    #expect("Configs" == "Configs")
 }

--- a/SNUTT/Modules/Feature/Notifications/Tests/NotificationsTests.swift
+++ b/SNUTT/Modules/Feature/Notifications/Tests/NotificationsTests.swift
@@ -2,5 +2,5 @@ import Foundation
 import Testing
 
 @Test func example() {
-    #expect("Settings" == "Settings")
+    #expect("Notifications" == "Notifications")
 }

--- a/SNUTT/Modules/Feature/Popup/Tests/PopupTests.swift
+++ b/SNUTT/Modules/Feature/Popup/Tests/PopupTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class PopupTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("Popup", "Popup")
-    }
+@Test func example() {
+    #expect("Popup" == "Popup")
 }

--- a/SNUTT/Modules/Feature/Themes/Tests/ThemesTests.swift
+++ b/SNUTT/Modules/Feature/Themes/Tests/ThemesTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class ThemesTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("Themes", "Themes")
-    }
+@Test func example() {
+    #expect("Themes" == "Themes")
 }

--- a/SNUTT/Modules/Feature/Timetable/Tests/TimetableTests.swift
+++ b/SNUTT/Modules/Feature/Timetable/Tests/TimetableTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class TimetableTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("Timetable", "Timetable")
-    }
+@Test func example() {
+    #expect("Timetable" == "Timetable")
 }

--- a/SNUTT/Modules/Feature/TimetableUIComponents/Tests/TimetableUIComponentsTests.swift
+++ b/SNUTT/Modules/Feature/TimetableUIComponents/Tests/TimetableUIComponentsTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class TimetableUIComponentsTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("TimetableUIComponents", "TimetableUIComponents")
-    }
+@Test func example() {
+    #expect("TimetableUIComponents" == "TimetableUIComponents")
 }

--- a/SNUTT/Modules/Feature/Vacancy/Tests/VacancyTests.swift
+++ b/SNUTT/Modules/Feature/Vacancy/Tests/VacancyTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class VacancyTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("Vacancy", "Vacancy")
-    }
+@Test func example() {
+    #expect("Vacancy" == "Vacancy")
 }

--- a/SNUTT/Modules/Shared/SharedAppMetadata/Tests/SharedAppMetadataTests.swift
+++ b/SNUTT/Modules/Shared/SharedAppMetadata/Tests/SharedAppMetadataTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class SharedAppMetadataTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("SharedAppMetadata", "SharedAppMetadata")
-    }
+@Test func example() {
+    #expect("SharedAppMetadata" == "SharedAppMetadata")
 }

--- a/SNUTT/Modules/Shared/SharedUIComponents/Tests/SharedUIComponentsTests.swift
+++ b/SNUTT/Modules/Shared/SharedUIComponents/Tests/SharedUIComponentsTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class SharedUIComponentsTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("SharedUIComponents", "SharedUIComponents")
-    }
+@Test func example() {
+    #expect("SharedUIComponents" == "SharedUIComponents")
 }

--- a/SNUTT/Modules/Utility/DependenciesUtility/Tests/DependenciesUtilityTests.swift
+++ b/SNUTT/Modules/Utility/DependenciesUtility/Tests/DependenciesUtilityTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class DependenciesUtilityTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("DependenciesUtility", "DependenciesUtility")
-    }
+@Test func example() {
+    #expect("DependenciesUtility" == "DependenciesUtility")
 }

--- a/SNUTT/Modules/Utility/FoundationUtility/Tests/FoundationUtilityTests.swift
+++ b/SNUTT/Modules/Utility/FoundationUtility/Tests/FoundationUtilityTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class FoundationUtilityTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("FoundationUtility", "FoundationUtility")
-    }
+@Test func example() {
+    #expect("FoundationUtility" == "FoundationUtility")
 }

--- a/SNUTT/Modules/Utility/SwiftUIUtility/Tests/SwiftUIUtilityTests.swift
+++ b/SNUTT/Modules/Utility/SwiftUIUtility/Tests/SwiftUIUtilityTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class SwiftUIUtilityTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("SwiftUIUtility", "SwiftUIUtility")
-    }
+@Test func example() {
+    #expect("SwiftUIUtility" == "SwiftUIUtility")
 }

--- a/SNUTT/Modules/Utility/UIKitUtility/Tests/UIKitUtilityTests.swift
+++ b/SNUTT/Modules/Utility/UIKitUtility/Tests/UIKitUtilityTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class UIKitUtilityTests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("UIKitUtility", "UIKitUtility")
-    }
+@Test func example() {
+    #expect("UIKitUtility" == "UIKitUtility")
 }

--- a/SNUTT/SNUTT/Tests/SNUTTTests.swift
+++ b/SNUTT/SNUTT/Tests/SNUTTTests.swift
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class SNUTTTests: XCTestCase {
-    func test_twoPlusTwo_isFour() {
-        XCTAssertEqual(2 + 2, 4)
-    }
+@Test func example() {
+    #expect("SNUTT" == "SNUTT")
 }

--- a/SNUTT/Tuist/Templates/feature/FeatureTests.stencil
+++ b/SNUTT/Tuist/Templates/feature/FeatureTests.stencil
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class {{ name }}Tests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("{{ name }}", "{{ name }}")
-    }
+@Test func example() {
+    #expect("{{ name }}" == "{{ name }}")
 }

--- a/SNUTT/Tuist/Templates/shared/SharedTests.stencil
+++ b/SNUTT/Tuist/Templates/shared/SharedTests.stencil
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class {{ name }}Tests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("{{ name }}", "{{ name }}")
-    }
+@Test func example() {
+    #expect("{{ name }}" == "{{ name }}")
 }

--- a/SNUTT/Tuist/Templates/utility/UtilityTests.stencil
+++ b/SNUTT/Tuist/Templates/utility/UtilityTests.stencil
@@ -1,8 +1,6 @@
 import Foundation
-import XCTest
+import Testing
 
-final class {{ name }}Tests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("{{ name }}", "{{ name }}")
-    }
+@Test func example() {
+    #expect("{{ name }}" == "{{ name }}")
 }


### PR DESCRIPTION
## 개요
테스트 프레임워크를 XCTest에서 Swift-Testing으로 마이그레이션합니다.

## 주요 변경사항
- 모든 모듈의 테스트 파일을 Swift-Testing 문법으로 변경
- `XCTAssertEqual` → `#expect` 문법 적용
- 테스트 템플릿 파일들도 함께 업데이트
- NotificationsTests 디렉토리 추가

## 영향도
- **Added lines**: ~60줄
- **Modified files**: 20개
- **Breaking changes**: 없음

## 테스트
```bash
tuist test
```