### PR TITLE
Prevent empty screen in `NetworkLogPresentationModifier`

### DIFF
--- a/Modules/Feature/APIClient/Sources/UI/Debug/NetworkLogPresentationModifier.swift
+++ b/Modules/Feature/APIClient/Sources/UI/Debug/NetworkLogPresentationModifier.swift
@@ -28,7 +28,7 @@ struct NetworkLogPresentationModifier: ViewModifier {
                     .presentationContentInteraction(.scrolls)
                 }
         } else {
-            EmptyView()
+            content
         }
     }
 }


### PR DESCRIPTION
### 수정사항
- `NetworkLogPresentationModifier`에서 18.0+ `UIGestureRecognizerRepresentable`을 사용하다보니 17.0에서는 네트워크 로그 시트 생성 안됨 + 생성 안될 시 `EmptyView()` 처리돼서 빈 화면 뜨는 문제 수정
- 17.0 에서는 `NetworkLogsScene` 시트 포기 ([참고](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1775958210766799))