### PR TITLE
Refine UI for theme settings, headers, and timetable rendering

### DIFF
--- a/Modules/Feature/Settings/Sources/UI/Timetable/TimetableSettingView.swift
+++ b/Modules/Feature/Settings/Sources/UI/Timetable/TimetableSettingView.swift
@@ -29,7 +29,7 @@ struct TimetableSettingView: View {
                 )
             } footer: {
                 if viewModel.configuration.compactMode {
-                    Text(SettingsStrings.displayTableInfoWarning)
+                    FormSectionFooter(SettingsStrings.displayTableInfoWarning)
                 }
             }
 
@@ -51,10 +51,9 @@ struct TimetableSettingView: View {
                     isOn: $viewModel.configuration.visibilityOptions.isInstructorEnabled
                 )
             } header: {
-                Text(SettingsStrings.displayTableInfo)
-                    .font(.system(size: 13))
+                FormSectionHeader(SettingsStrings.displayTableInfo)
             } footer: {
-                Text(SettingsStrings.displayTableInfoWarning)
+                FormSectionFooter(SettingsStrings.displayTableInfoWarning)
             }
 
             if !viewModel.configuration.autoFit {
@@ -75,8 +74,7 @@ struct TimetableSettingView: View {
                         .frame(height: 40)
                     }
                 } header: {
-                    Text(SettingsStrings.displayTableRange)
-                        .font(.system(size: 13))
+                    FormSectionHeader(SettingsStrings.displayTableRange)
                 }
             }
 
@@ -98,8 +96,7 @@ struct TimetableSettingView: View {
                     )
                     .padding(.vertical, 10)
                 } header: {
-                    Text(SettingsStrings.displayTablePreview)
-                        .font(.system(size: 13))
+                    FormSectionHeader(SettingsStrings.displayTablePreview)
                 }
             }
         }

--- a/Modules/Feature/Settings/Sources/UI/Timetable/TimetableSettingView.swift
+++ b/Modules/Feature/Settings/Sources/UI/Timetable/TimetableSettingView.swift
@@ -52,12 +52,13 @@ struct TimetableSettingView: View {
                 )
             } header: {
                 Text(SettingsStrings.displayTableInfo)
+                    .font(.system(size: 13))
             } footer: {
                 Text(SettingsStrings.displayTableInfoWarning)
             }
 
             if !viewModel.configuration.autoFit {
-                Section(SettingsStrings.displayTableRange) {
+                Section {
                     SettingsNavigationLink(
                         title: SettingsStrings.displayTableDaySelection,
                         value: SettingsPathType.timetableRange,
@@ -73,11 +74,14 @@ struct TimetableSettingView: View {
                         )
                         .frame(height: 40)
                     }
+                } header: {
+                    Text(SettingsStrings.displayTableRange)
+                        .font(.system(size: 13))
                 }
             }
 
             if let timetable = viewModel.timetable {
-                Section(SettingsStrings.displayTablePreview) {
+                Section {
                     timetableUIProvider.timetableView(
                         timetable: timetable,
                         configuration: viewModel.configuration,
@@ -93,6 +97,9 @@ struct TimetableSettingView: View {
                             .shadow(color: .black.opacity(0.05), radius: 3)
                     )
                     .padding(.vertical, 10)
+                } header: {
+                    Text(SettingsStrings.displayTablePreview)
+                        .font(.system(size: 13))
                 }
             }
         }

--- a/Modules/Feature/Settings/Sources/UI/UserSupport/UserSupportScene.swift
+++ b/Modules/Feature/Settings/Sources/UI/UserSupport/UserSupportScene.swift
@@ -18,21 +18,26 @@ struct UserSupportScene: View {
 
     var body: some View {
         Form {
-            Section(header: Text(SettingsStrings.feedbackEmailHeader)) {
+            Section {
                 TextField(SettingsStrings.feedbackEmailPlaceholder, text: $viewModel.email)
                     .foregroundColor(viewModel.hasEmail ? .secondary : .primary)
                     .disabled(viewModel.hasEmail)
                     .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
+            } header: {
+                Text(SettingsStrings.feedbackEmailHeader)
+                    .font(.system(size: 13))
             }
 
-            Section(
-                header: Text(SettingsStrings.feedbackContentHeader),
-                footer: Text(SettingsStrings.feedbackContentFooter)
-            ) {
+            Section {
                 TextEditor(text: $viewModel.content)
                     .frame(minHeight: 300)
                     .focused($isFocused)
+            } header: {
+                Text(SettingsStrings.feedbackContentHeader)
+                    .font(.system(size: 13))
+            } footer: {
+                Text(SettingsStrings.feedbackContentFooter)
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/Modules/Feature/Themes/Resources/Base.lproj/Localizable.strings
+++ b/Modules/Feature/Themes/Resources/Base.lproj/Localizable.strings
@@ -19,9 +19,15 @@
  - Add comments to provide context for translators.
 */
 
-/* Add your translations below */
+/* Theme Settings Scene */
+"settings.title" = "시간표 테마";
+"settings.custom" = "커스텀 테마";
+"settings.downloaded" = "담은 테마";
+"settings.basic" = "제공 테마";
 
-"hello_world" = "Hello, world!";
+"settings.howto.question" = "테마는 어떻게 적용하나요?";
+"settings.howto.answer1" = "시간표 적용은 시간표 목록 > 더보기 버튼 > 테마 설정에서 개별적으로 적용할 수 있어요.";
+"settings.howto.answer2" = "새로운 시간표에는 가장 최근 편집한 커스텀 테마가 적용돼요.";
 
 /* Theme Edit Detail Scene */
 "newTheme" = "새 테마";

--- a/Modules/Feature/Themes/Resources/en.lproj/Localizable.strings
+++ b/Modules/Feature/Themes/Resources/en.lproj/Localizable.strings
@@ -19,9 +19,15 @@
  - Add comments to provide context for translators.
 */
 
-/* Add your translations below */
+/* Theme Settings Scene */
+"settings.title" = "Timetable Theme";
+"settings.custom" = "Custom Themes";
+"settings.downloaded" = "Downloaded Themes";
+"settings.basic" = "Basic Themes";
 
-"hello_world" = "Hello, world!";
+"settings.howto.question" = "How do I apply a theme?";
+"settings.howto.answer1" = "You can apply a theme individually by going to Timetable List > More button > Theme Settings.";
+"settings.howto.answer2" = "The most recently edited custom theme will be applied to new timetables.";
 
 /* Theme Edit Detail Scene */
 "newTheme" = "New Theme";

--- a/Modules/Feature/Themes/Sources/UI/Components/ThemeHorizontalScrollView.swift
+++ b/Modules/Feature/Themes/Sources/UI/Components/ThemeHorizontalScrollView.swift
@@ -25,7 +25,7 @@ struct ThemeHorizontalScrollView: View {
                                 .resizable()
                                 .scaledToFit()
                                 .frame(width: 80, height: 80)
-                            Text("새 테마")
+                            Text(ThemesStrings.newTheme)
                                 .font(.system(size: 14))
                                 .padding(.top, 5)
                         }

--- a/Modules/Feature/Themes/Sources/UI/ThemeEditDetailScene.swift
+++ b/Modules/Feature/Themes/Sources/UI/ThemeEditDetailScene.swift
@@ -71,17 +71,20 @@ struct ThemeEditDetailScene: View {
     }
 
     private var themeNameSection: some View {
-        Section(ThemesStrings.themeName) {
+        Section {
             if viewModel.isThemeEditable {
                 TextField(ThemesStrings.themeName, text: $viewModel.editableTheme.name)
             } else {
                 Text(viewModel.editableTheme.name)
             }
+        } header: {
+            Text(ThemesStrings.themeName)
+                .font(.system(size: 13))
         }
     }
 
     private var colorCombinationSection: some View {
-        Section(ThemesStrings.colorCombination) {
+        Section {
             ForEach(Array(viewModel.identifiableColors.enumerated()), id: \.element.id) { index, identifiableColor in
                 if viewModel.isThemeEditable {
                     editableColorRow(index: index, identifiableColor: identifiableColor)
@@ -99,6 +102,9 @@ struct ThemeEditDetailScene: View {
                     Label(ThemesStrings.addColor, systemImage: "plus")
                 }
             }
+        } header: {
+            Text(ThemesStrings.colorCombination)
+                .font(.system(size: 13))
         }
     }
 
@@ -165,12 +171,15 @@ struct ThemeEditDetailScene: View {
     @ViewBuilder
     private var previewSection: some View {
         if let timetable = viewModel.timetable {
-            Section(ThemesStrings.preview) {
+            Section {
                 TimetableThemePreview(
                     timetable: timetable,
                     configuration: viewModel.configuration,
                     theme: viewModel.editableTheme
                 )
+            } header: {
+                Text(ThemesStrings.preview)
+                    .font(.system(size: 13))
             }
         }
     }

--- a/Modules/Feature/Themes/Sources/UI/ThemeSettingsScene.swift
+++ b/Modules/Feature/Themes/Sources/UI/ThemeSettingsScene.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2026 wafflestudio.com. All rights reserved.
 //
 
+import SharedUIComponents
 import SwiftUI
 import ThemesInterface
 
@@ -15,7 +16,7 @@ struct ThemeSettingsScene: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Custom Themes")) {
+            Section {
                 ThemeHorizontalScrollView(
                     themes: customThemes,
                     onTapCreateButton: {
@@ -31,30 +32,40 @@ struct ThemeSettingsScene: View {
                     }
                     .presentationDetents([.large])
                 }
+            } header: {
+                Text(ThemesStrings.settingsCustom)
+                    .font(.system(size: 13))
             }
 
             if !downloadedThemes.isEmpty {
-                Section(header: Text("Downloaded Themes")) {
+                Section {
                     ThemeHorizontalScrollView(
                         themes: downloadedThemes,
                         onTapTheme: { theme in
                             themeForBottomSheet = theme
                         }
                     )
+                } header: {
+                    Text(ThemesStrings.downloadedTheme)
+                        .font(.system(size: 13))
                 }
             }
 
-            Section(header: Text("Basic Themes"), footer: HowToApplyThemeInfoView()) {
+            Section {
                 ThemeHorizontalScrollView(
                     themes: basicThemes,
                     onTapTheme: { theme in
                         themeForBottomSheet = theme
                     }
                 )
+            } header: {
+                Text(ThemesStrings.settingsBasic)
+                    .font(.system(size: 13))
+            } footer: {
+                HowToApplyThemeInfoView()
             }
-
         }
-        .navigationTitle("시간표 테마")
+        .navigationTitle(ThemesStrings.settingsTitle)
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $themeForBottomSheet) { theme in
             ThemeDetailSheet(theme: theme)
@@ -81,20 +92,23 @@ struct ThemeSettingsScene: View {
 
 private struct HowToApplyThemeInfoView: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
                 Image(systemName: "info.circle")
                     .resizable()
                     .frame(width: 14, height: 14)
-                Text("테마는 어떻게 적용하나요?")
+                Text(ThemesStrings.settingsHowtoQuestion)
                     .font(.system(size: 12, weight: .bold))
             }
-            Text("시간표 적용은 시간표 목록 > 더보기 버튼 > 테마 설정에서 개별적으로 적용할 수 있어요.")
-                .font(.system(size: 12))
-                .lineSpacing(1.3)
-            Text("새로운 시간표에는 가장 최근 편집한 커스텀 테마가 적용돼요.")
-                .font(.system(size: 12))
+            Group {
+                Text(ThemesStrings.settingsHowtoAnswer1)
+                    .lineSpacing(1.3)
+                Text(ThemesStrings.settingsHowtoAnswer2)
+            }
+            .font(.system(size: 12))
         }
-        .padding(.top, 25)
+        .padding(.top, 24)
+        .padding(.bottom, 40)
+        .foregroundStyle(SharedUIComponentsAsset.gray2.swiftUIColor)
     }
 }

--- a/Modules/Feature/Themes/Sources/UI/ThemeSettingsScene.swift
+++ b/Modules/Feature/Themes/Sources/UI/ThemeSettingsScene.swift
@@ -33,8 +33,7 @@ struct ThemeSettingsScene: View {
                     .presentationDetents([.large])
                 }
             } header: {
-                Text(ThemesStrings.settingsCustom)
-                    .font(.system(size: 13))
+                FormSectionHeader(ThemesStrings.settingsCustom)
             }
 
             if !downloadedThemes.isEmpty {
@@ -46,8 +45,7 @@ struct ThemeSettingsScene: View {
                         }
                     )
                 } header: {
-                    Text(ThemesStrings.downloadedTheme)
-                        .font(.system(size: 13))
+                    FormSectionHeader(ThemesStrings.downloadedTheme)
                 }
             }
 
@@ -59,8 +57,7 @@ struct ThemeSettingsScene: View {
                     }
                 )
             } header: {
-                Text(ThemesStrings.settingsBasic)
-                    .font(.system(size: 13))
+                FormSectionHeader(ThemesStrings.settingsBasic)
             } footer: {
                 HowToApplyThemeInfoView()
             }

--- a/Modules/Feature/Timetable/Sources/Infra/SwiftUITimetableImageRenderer.swift
+++ b/Modules/Feature/Timetable/Sources/Infra/SwiftUITimetableImageRenderer.swift
@@ -11,6 +11,10 @@ import TimetableInterface
 import TimetableUIComponents
 
 struct SwiftUITimetableImageRenderer: TimetableImageRenderer {
+    private enum Layout {
+        static let aspectRatio: CGFloat = 1.5
+    }
+
     @MainActor
     func render(
         timetable: Timetable,
@@ -25,16 +29,19 @@ struct SwiftUITimetableImageRenderer: TimetableImageRenderer {
             availableThemes: availableThemes,
             configuration: configuration
         )
-        let screenSize = UIScreen.main.bounds.size
-        let timetableView = TimetableForCapture(
-            painter: painter,
-            size: .init(width: screenSize.width, height: screenSize.width * 1.5)
-        )
-        .frame(width: screenSize.width, height: screenSize.height)
-        .background(Color(uiColor: .systemBackground))
-        .environment(\.colorScheme, colorScheme)
+        guard
+            let scene = UIApplication.shared.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+        else { throw RenderingError() }
+
+        let screenWidth = scene.screen.bounds.width
+        let timetableSize = CGSize(width: screenWidth, height: screenWidth * Layout.aspectRatio)
+        let timetableView = TimetableForCapture(painter: painter, size: timetableSize)
+            .frame(width: timetableSize.width, height: timetableSize.height)
+            .background(Color(uiColor: .systemBackground))
+            .environment(\.colorScheme, colorScheme)
         let renderer = ImageRenderer(content: timetableView)
-        renderer.scale = UIScreen.main.scale
+        renderer.scale = scene.screen.scale
         guard let image = renderer.uiImage else { throw RenderingError() }
         return image
     }

--- a/Modules/Feature/Timetable/Sources/UI/LectureReminder/LectureReminderSettingsScene.swift
+++ b/Modules/Feature/Timetable/Sources/UI/LectureReminder/LectureReminderSettingsScene.swift
@@ -64,6 +64,7 @@ public struct LectureReminderSettingsScene: View {
                     } header: {
                         Text(TimetableStrings.reminderSettingsHeader)
                             .foregroundStyle(SharedUIComponentsAsset.gray30.swiftUIColor)
+                            .font(.system(size: 13))
                     } footer: {
                         Text(TimetableStrings.reminderSettingsFooter.asMarkdown())
                             .font(.systemFont(ofSize: 13), lineHeightMultiple: 1.4)

--- a/Modules/Feature/Timetable/Sources/UI/TimetableMenu/MenuEllipsisSheet.swift
+++ b/Modules/Feature/Timetable/Sources/UI/TimetableMenu/MenuEllipsisSheet.swift
@@ -58,7 +58,7 @@ struct MenuEllipsisSheet: View {
                 menuSheetDismiss()
                 viewModel.presentThemeSheet()
             }
-            ActionSheetItem(image: Menu.delete.image, title: Menu.delete.text) {
+            ActionSheetItem(image: Menu.delete.image, title: Menu.delete.text, role: .destructive) {
                 dismiss()
                 errorAlertHandler.withAlert {
                     try await viewModel.deleteTimetable(timetableID: metadata.id)

--- a/Modules/Shared/SharedUIComponents/Sources/ActionSheet/ActionSheet.swift
+++ b/Modules/Shared/SharedUIComponents/Sources/ActionSheet/ActionSheet.swift
@@ -33,7 +33,7 @@ public struct ActionSheet: View {
         .mask {
             ContainerRelativeShape().inset(by: Design.padding).ignoresSafeArea(edges: .bottom)
         }
-        .presentationDetents([.height(ActionSheetLabel.rowHeight * CGFloat(items.count) + 20)])
+        .presentationDetents([.height(ActionSheetLabel.rowHeight * CGFloat(items.count) + Design.padding * 2)])
     }
 }
 

--- a/Modules/Shared/SharedUIComponents/Sources/FormSectionFooter.swift
+++ b/Modules/Shared/SharedUIComponents/Sources/FormSectionFooter.swift
@@ -1,0 +1,22 @@
+//
+//  FormSectionFooter.swift
+//  SNUTT
+//
+//  Copyright © 2026 wafflestudio.com. All rights reserved.
+//
+
+import SwiftUI
+
+public struct FormSectionFooter: View {
+    let title: String
+
+    public init(_ title: String) {
+        self.title = title
+    }
+
+    public var body: some View {
+        Text(title)
+            .font(.footnote)
+            .dynamicTypeSize(.xSmall ... .xLarge)
+    }
+}

--- a/Modules/Shared/SharedUIComponents/Sources/FormSectionHeader.swift
+++ b/Modules/Shared/SharedUIComponents/Sources/FormSectionHeader.swift
@@ -1,0 +1,22 @@
+//
+//  FormSectionHeader.swift
+//  SNUTT
+//
+//  Copyright © 2026 wafflestudio.com. All rights reserved.
+//
+
+import SwiftUI
+
+public struct FormSectionHeader: View {
+    let title: String
+
+    public init(_ title: String) {
+        self.title = title
+    }
+
+    public var body: some View {
+        Text(title)
+            .font(.footnote.bold())
+            .dynamicTypeSize(.xSmall ... .xLarge)
+    }
+}


### PR DESCRIPTION
### 수정사항
- '더보기 > 시간표 테마' 화면에서 다국어 지원 깨진 부분 수정
- Section header font 사이즈 정리
- 시간표 이미지 공유하는 코드에서 `UIScreen.main` 사용하는 부분 제거 ([deprecated](https://developer.apple.com/documentation/uikit/uiscreen-deprecated-symbols))