### PR TITLE
Change English search tips to Korean

### DIFF
--- a/Modules/Feature/Timetable/Resources/en.lproj/Localizable.strings
+++ b/Modules/Feature/Timetable/Resources/en.lproj/Localizable.strings
@@ -59,13 +59,13 @@
 "search.result.empty.description" = "Please try again with different search terms";
 "search.bookmark.empty.title" = "No bookmarked courses.";
 "search.bookmark.empty.description" = "Add courses you're considering\nto your bookmarks to manage them.";
-"search.tips.title" = "SNUTT Search Tips 🍯";
+"search.tips.title" = "SNUTT Search Tips 🍯\n(Korean only)";
 "search.tips.combination.title" = "Try searching with various combinations.";
-"search.tips.combination.example" = "ex) 2nd year CS required / Business English";
+"search.tips.combination.example" = "ex) 2학년 컴공 전필 / 경영 영강";
 "search.tips.abbreviation.title" = "Try searching with abbreviations.";
-"search.tips.abbreviation.example" = "ex) Scientific Understanding of Death Yoo Seong-ho → 죽과이 유성호";
+"search.tips.abbreviation.example" = "ex) 죽음의 과학적 이해 유성호 → 죽과이 유성호";
 "search.tips.location.title" = "Try searching by classroom location.";
-"search.tips.location.example" = "ex) Building 26 / 302-108 / Daegul2 43-1";
+"search.tips.location.example" = "ex) 26동 / 302-108 / 대글2 43-1동";
 "search.bookmark.title" = "Bookmarks";
 "search.title" = "Search";
 

--- a/Modules/Feature/Timetable/Sources/UI/LectureSearch/SearchTipsView.swift
+++ b/Modules/Feature/Timetable/Sources/UI/LectureSearch/SearchTipsView.swift
@@ -52,6 +52,7 @@ struct SearchTipsView: View {
             Spacer()
         }
         .padding(.horizontal)
+        .multilineTextAlignment(.center)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
         .foregroundColor(.white.opacity(0.9))


### PR DESCRIPTION
### 수정사항
- 줄임말 검색/장소 검색 등은 한국어에만 적용되므로 안내 문구 변경

- - -

| 변경 전 | 변경 후 |
|---|---|
| <img width="645" height="1398" alt="IMG_0297" src="https://github.com/user-attachments/assets/349514de-ee8b-4db9-b2b2-f73bf12a51d6" /> | <img width="645" height="1398" alt="IMG_0296" src="https://github.com/user-attachments/assets/dac9a458-ed1b-4837-abde-7ff9b5d0dacd" /> |